### PR TITLE
Support block height query relative to a genesis index

### DIFF
--- a/concordium_p2p_rpc.proto
+++ b/concordium_p2p_rpc.proto
@@ -131,6 +131,10 @@ message GetTransactionStatusInBlockRequest {
 
 message BlockHeight {
   uint64 block_height = 1 [jstype = JS_STRING];
+  //! The block height is relative to the genesis block at this index.
+  uint32 from_genesis_index = 2;
+  //! If true, only return results from the specified genesis index.
+  bool restrict_to_genesis_index = 3;
 }
 
 service P2P {


### PR DESCRIPTION
## Purpose

This adds the possibility of specifying a base genesis index when calling `GetBlocksByHeight`. The height is treated as relative to this index. It is also possible to restrict the query to the specified genesis index.

## Changes

Add the fields `from_genesis_index` and `restrict_to_genesis_index` to the `BlockHeight` message type. (As we are using proto3, these are automatically optional, and default to 0 and false, respectively. This means that if they are not provided the height will be treated as an absolute height.)

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
