### PR TITLE
First round of gRPC api v2 functions

### DIFF
--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -18,8 +18,19 @@ service Queries {
   // Get a list of all smart contract modules. The stream will end
   // when all modules that exist in the state at the end of the given
   // block have been returned.
-  rpc GetModuleList (BlockHashInput) returns (stream ModuleReference);
+  rpc GetModuleList (BlockHashInput) returns (stream ModuleRef);
 
   // Get ancestors for the provided block.
   rpc GetAncestors (AncestorsRequest) returns (stream BlockHash);
+
+  // Get the source of a smart contract module.
+  rpc GetModuleSource (ModuleSourceRequest) returns (ModuleSource);
+
+  // Get a list of addresses for all smart contract instances. The stream
+  // will end when all instances that exist in the state at the end of the
+  // given block has been returned.
+  rpc GetInstanceList (BlockHashInput) returns (stream ContractAddress);
+
+  // Get info about a smart contract instance as it appears in the given block.
+  rpc GetInstanceInfo (InstanceInfoRequest) returns (InstanceInfo);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -34,8 +34,11 @@ service Queries {
   // Get info about a smart contract instance as it appears in the given block.
   rpc GetInstanceInfo (InstanceInfoRequest) returns (InstanceInfo);
 
-  // Get the next account nonce
+  // Get the next account nonce.
   rpc GetNextAccountNonce (AccountIdentifierInput) returns (NextAccountNonce);
+
+  // Get the consensus status.
+  rpc GetConsensusInfo (Empty) returns (ConsensusInfo);
 
   // Get the status of and information about a specific transaction.
   rpc GetTransactionStatus (TransactionHash) returns (TransactionStatus);

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -27,7 +27,9 @@ service Queries {
   // block have been returned.
   rpc GetModuleList (BlockHashInput) returns (stream ModuleRef);
 
-  // Get ancestors for the provided block.
+  // Get a stream of ancestors for the provided block.
+  // Starting with the provided block itself, moving backwards until no more
+  // ancestors or the requested number of ancestors has been returned.
   rpc GetAncestors (AncestorsRequest) returns (stream BlockHash);
 
   // Get the source of a smart contract module.
@@ -38,7 +40,8 @@ service Queries {
   // given block has been returned.
   rpc GetInstanceList (BlockHashInput) returns (stream ContractAddress);
 
-  // Get info about a smart contract instance as it appears in the given block.
+  // Get info about a smart contract instance as it appears at the end of the
+  // given block.
   rpc GetInstanceInfo (InstanceInfoRequest) returns (InstanceInfo);
 
   // Get the best guess as to what the next account sequence number should be.
@@ -47,7 +50,7 @@ service Queries {
   // committed to blocks and eventually finalized.
   rpc GetNextAccountSequenceNumber (AccountIdentifierInput) returns (NextAccountSequenceNumber);
 
-  // Get information of the current state of consensus.
+  // Get information about the current state of consensus.
   rpc GetConsensusInfo (Empty) returns (ConsensusInfo);
 
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -10,4 +10,6 @@ service Queries {
   rpc GetAccountInfo (AccountInfoRequest) returns (AccountInfo);
 
   rpc GetAccountList (BlockHashInput) returns (stream AccountAddress);
+
+  rpc GetModuleList (BlockHashInput) returns (stream ModuleReference);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -33,7 +33,7 @@ service Queries {
   rpc GetAncestors (AncestorsRequest) returns (stream BlockHash);
 
   // Get the source of a smart contract module.
-  rpc GetModuleSource (ModuleSourceRequest) returns (ModuleSource);
+  rpc GetModuleSource (ModuleSourceRequest) returns (VersionedModuleSource);
 
   // Get a list of addresses for all smart contract instances. The stream
   // will end when all instances that exist in the state at the end of the

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -50,6 +50,4 @@ service Queries {
   // Get information of the current state of consensus.
   rpc GetConsensusInfo (Empty) returns (ConsensusInfo);
 
-  // Get the status of and information about a specific transaction.
-  rpc GetTransactionStatus (TransactionHash) returns (TransactionStatus);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -41,10 +41,13 @@ service Queries {
   // Get info about a smart contract instance as it appears in the given block.
   rpc GetInstanceInfo (InstanceInfoRequest) returns (InstanceInfo);
 
-  // Get the next account sequence number.
+  // Get the best guess as to what the next account sequence number should be.
+  // If all account transactions are finalized then this information is reliable.
+  // Otherwise this is the best guess, assuming all other transactions will be
+  // committed to blocks and eventually finalized.
   rpc GetNextAccountSequenceNumber (AccountIdentifierInput) returns (NextAccountSequenceNumber);
 
-  // Get the consensus status.
+  // Get information of the current state of consensus.
   rpc GetConsensusInfo (Empty) returns (ConsensusInfo);
 
   // Get the status of and information about a specific transaction.

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -33,4 +33,7 @@ service Queries {
 
   // Get info about a smart contract instance as it appears in the given block.
   rpc GetInstanceInfo (InstanceInfoRequest) returns (InstanceInfo);
+
+  // Get the status of and information about a specific transaction.
+  rpc GetTransactionStatus (TransactionHash) returns (TransactionStatus);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -5,11 +5,21 @@ import "v2/concordium/types.proto";
 package concordium.v2;
 
 service Queries {
+  // Get a stream of finalized blocks. The stream will continue indefinitely.
   rpc GetFinalizedBlocks (Empty) returns (stream FinalizedBlockInfo);
 
+  // Get information about the requested account.
   rpc GetAccountInfo (AccountInfoRequest) returns (AccountInfo);
 
+  // Get a list of all accounts. The stream will end when all accounts
+  // that exist in the state at the end of the given block have been returned.
   rpc GetAccountList (BlockHashInput) returns (stream AccountAddress);
 
+  // Get a list of all smart contract modules. The stream will end
+  // when all modules that exist in the state at the end of the given
+  // block have been returned.
   rpc GetModuleList (BlockHashInput) returns (stream ModuleReference);
+
+  // Get ancestors for the provided block.
+  rpc GetAncestors (AncestorsRequest) returns (stream BlockHash);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -34,6 +34,9 @@ service Queries {
   // Get info about a smart contract instance as it appears in the given block.
   rpc GetInstanceInfo (InstanceInfoRequest) returns (InstanceInfo);
 
+  // Get the next account nonce
+  rpc GetNextAccountNonce (AccountIdentifierInput) returns (NextAccountNonce);
+
   // Get the status of and information about a specific transaction.
   rpc GetTransactionStatus (TransactionHash) returns (TransactionStatus);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -48,7 +48,7 @@ service Queries {
   // If all account transactions are finalized then this information is reliable.
   // Otherwise this is the best guess, assuming all other transactions will be
   // committed to blocks and eventually finalized.
-  rpc GetNextAccountSequenceNumber (AccountIdentifierInput) returns (NextAccountSequenceNumber);
+  rpc GetNextAccountSequenceNumber (AccountAddress) returns (NextAccountSequenceNumber);
 
   // Get information about the current state of consensus.
   rpc GetConsensusInfo (Empty) returns (ConsensusInfo);

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -559,19 +559,19 @@ message InstanceInfo {
 }
 
 // The receive name of a smart contract function. Expected format: "<contract_name>.<func_name>".
-// It must only consist of atmost 100 ascii alphanumeric or punctuation characters, and must contain a '.'.
+// It must only consist of atmost 100 ASCII alphanumeric or punctuation characters, and must contain a '.'.
 message ReceiveName {
   string value = 1;
 }
 
 // The init name of a smart contract function. Expected format: "init_<contract_name>".
-// It must only consist of atmost 100 ascii alphanumeric or punctuation characters, must not contain a '.' and must start with 'init_'.
+// It must only consist of atmost 100 ASCII alphanumeric or punctuation characters, must not contain a '.' and must start with 'init_'.
 message InitName {
   string value = 1;
 }
 
 // A smart contract v0 state.
-message ContractState {
+message ContractStateV0 {
   bytes value = 1;
 }
 
@@ -632,47 +632,47 @@ message ConsensusInfo {
   uint32 blocks_received_count = 9;
   // The last time a block was received.
   optional Timestamp block_last_received_time = 10;
-  // Moving average latency between a block's slot time and received time.
+  // Exponential moving average latency between a block's slot time and received time.
   double block_receive_latency_ema = 11;
-  // Standard deviation of moving average latency between a block's slot time and received time.
+  // Standard deviation of exponential moving average latency between a block's slot time and received time.
   double block_receive_latency_emsd = 12;
-  // Moving average time between receiving blocks.
+  // Exponential moving average time between receiving blocks.
   optional double block_receive_period_ema = 13;
-  // Standard deviation of moving average time between receiving blocks.
+  // Standard deviation of exponential moving average time between receiving blocks.
   optional double block_receive_period_emsd = 14;
   // Total number of blocks received and verified.
   uint32 blocks_verified_count = 15;
   // The last time a block was verified (added to the tree).
   optional Timestamp block_last_arrived_time = 16;
-  // Moving average latency between a block's slot time and its arrival.
+  // Exponential moving average latency between a block's slot time and its arrival.
   double block_arrive_latency_ema = 17;
-  // Standard deviation of moving average latency between a block's slot time and its arrival.
+  // Standard deviation of exponential moving average latency between a block's slot time and its arrival.
   double block_arrive_latency_emsd = 18;
-  // Moving average time between block arrivals.
+  // Exponential moving average time between block arrivals.
   optional double block_arrive_period_ema = 19;
-  // Standard deviation of moving average time between block arrivals.
+  // Standard deviation of exponential moving average time between block arrivals.
   optional double block_arrive_period_emsd = 20;
-  // Moving average number of transactions per block.
+  // Exponential moving average number of transactions per block.
   double transactions_per_block_ema = 21;
-  // Standard deviation of moving average number of transactions per block.
+  // Standard deviation of exponential moving average number of transactions per block.
   double transactions_per_block_emsd = 22;
   // Number of finalizations.
   uint32 finalization_count = 23;
   // Time of last verified finalization.
   optional Timestamp last_finalized_time = 24;
-  // Moving average time between finalizations.
+  // Exponential moving average time between finalizations.
   optional double finalization_period_ema = 25;
-  // Standard deviation of moving average time between finalizations.
+  // Standard deviation of exponential moving average time between finalizations.
   optional double finalization_period_emsd = 26;
   // Currently active protocol version.
   ProtocolVersion protocol_version = 27;
-  // The number of chain restarts via a protocol update. An effected
+  // The number of chain restarts via a protocol update. A completed
   // protocol update instruction might not change the protocol version
   // specified in the previous field, but it always increments the genesis
   // index.
   GenesisIndex genesis_index = 28;
   // Block hash of the genesis block of current era, i.e., since the last protocol update.
-  // Initially this is equal to 'csGenesisBlock'.
+  // Initially this is equal to 'genesis_block'.
   BlockHash current_era_genesis_block = 29;
   // Time when the current era started.
   Timestamp current_era_genesis_time = 30;

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -37,6 +37,11 @@ message AccountIndex {
   uint64 value = 1;
 }
 
+/// Hash of a smart contract module. This is always 32 bytes long.
+message ModuleReference {
+  bytes value = 1;
+}
+
 // An individual release of a locked balance.
 message Release {
   // Effective time of the release in milliseconds since unix epoch.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -37,8 +37,14 @@ message AccountIndex {
   uint64 value = 1;
 }
 
-/// Hash of a smart contract module. This is always 32 bytes long.
-message ModuleReference {
+// Reference (hash) of a smart contract module. This is always 32 bytes long.
+message ModuleRef {
+  bytes value = 1;
+}
+
+//! Source bytes of a smart contract module.
+// ok test
+message ModuleSource {
   bytes value = 1;
 }
 
@@ -234,7 +240,7 @@ message Amount {
   uint64 value = 1;
 }
 
-// The amount of microCCD.
+// A credential index of an account.
 message CredentialIndex {
   uint32 value = 1;
 }
@@ -444,4 +450,65 @@ message AncestorsRequest {
   BlockHashInput block_hash = 1;
   // The maximum number of ancestors returned.
   uint64 amount = 2;
+}
+
+// Request for getting the source of a smart contract module.
+message ModuleSourceRequest {
+  // The block to be used for the query.
+  BlockHashInput block_hash = 1;
+
+  // The reference (hash) of the module.
+  ModuleRef module_ref = 2;
+}
+
+// Address of a smart contract instance.
+message ContractAddress {
+  // The index of the smart contract.
+  uint64 index = 1;
+  // The subindex of the smart contract instance.
+  // Currently not used, so it is always 0.
+  uint64 subindex = 2;
+}
+
+message InstanceInfoRequest {
+  BlockHashInput block_hash = 1;
+  ContractAddress address = 2;
+}
+
+// Information about a smart contract instance.
+message InstanceInfo {
+
+  message V0 {
+    ContractState model = 1;
+    AccountAddress owner = 2;
+    Amount amount = 3;
+    repeated ReceiveName methods = 4;
+    InitName name = 5;
+    ModuleRef source_module = 6;
+  }
+
+  message V1 {
+    AccountAddress owner = 2;
+    Amount amount = 3;
+    repeated ReceiveName methods = 4;
+    InitName name = 5;
+    ModuleRef source_module = 6;
+  }
+
+  oneof version {
+    V0 v0 = 1;
+    V1 v1 = 2;
+  }
+}
+
+message ReceiveName {
+  string value = 1;
+}
+
+message InitName {
+  string value = 1;
+}
+
+message ContractState {
+  bytes value = 1;
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -643,3 +643,89 @@ message NextAccountNonce {
   Nonce nonce = 1;
   bool all_final = 2;
 }
+
+message Timestamp {
+  uint64 value = 1;
+}
+
+message Duration {
+  uint64 value = 1;
+}
+
+enum ProtocolVersion {
+  PROTOCOL_VERSION_1 = 0;
+  PROTOCOL_VERSION_2 = 1;
+  PROTOCOL_VERSION_3 = 2;
+  PROTOCOL_VERSION_4 = 3;
+}
+
+message GenesisIndex {
+  uint32 value = 1;
+}
+
+message ConsensusInfo {
+  // Hash of the current best block
+  BlockHash best_block = 1;
+  // Hash of the (original) genesis block
+  BlockHash genesis_block = 2;
+  // Time of the (original) genesis block
+  Timestamp genesis_time = 3;
+  // (Current) slot duration in milliseconds
+  Duration slot_duration = 4;
+  // (Current) epoch duration in milliseconds
+  Duration epoch_duration = 5;
+  // Hash of the last finalized block
+  BlockHash last_finalized_block = 6;
+  // Absolute height of the best block
+  AbsoluteBlockHeight best_block_height = 7;
+  // Absolute height of the last finalized block
+  AbsoluteBlockHeight last_finalized_block_height = 8;
+  // Total number of blocks received
+  uint32 blocks_received_count = 9;
+  // The last time a block was received
+  optional Timestamp block_last_received_time = 10;
+  // Moving average latency between a block's slot time and received time
+  double block_receive_latency_ema = 11;
+  // Standard deviation of moving average latency between a block's slot time and received time
+  double block_receive_latency_emsd = 12;
+  // Moving average time between receiving blocks
+  optional double block_receive_period_ema = 13;
+  // Standard deviation of moving average time between receiving blocks
+  optional double block_receive_period_emsd = 14;
+  // Total number of blocks received and verified
+  uint32 blocks_verified_count = 15;
+  // The last time a block was verified (added to the tree)
+  optional Timestamp block_last_arrived_time = 16;
+  // Moving average latency between a block's slot time and its arrival
+  double block_arrive_latency_ema = 17;
+  // Standard deviation of moving average latency between a block's slot time and its arrival
+  double block_arrive_latency_emsd = 18;
+  // Moving average time between block arrivals
+  optional double block_arrive_period_ema = 19;
+  // Standard deviation of moving average time between block arrivals
+  optional double block_arrive_period_emsd = 20;
+  // Moving average number of transactions per block
+  double transactions_per_block_ema = 21;
+  // Standard deviation of moving average number of transactions per block
+  double transactions_per_block_emsd = 22;
+  // Number of finalizations
+  uint32 finalization_count = 23;
+  // Time of last verified finalization
+  optional Timestamp last_finalized_time = 24;
+  // Moving average time between finalizations
+  optional double finalization_period_ema = 25;
+  // Standard deviation of moving average time between finalizations
+  optional double finalization_period_emsd = 26;
+  // Currently active protocol version.
+  ProtocolVersion protocol_version = 27;
+  // The number of chain restarts via a protocol update. An effected
+  // protocol update instruction might not change the protocol version
+  // specified in the previous field, but it always increments the genesis
+  // index.
+  GenesisIndex genesis_index = 28;
+  // Block hash of the genesis block of current era, i.e., since the last protocol update.
+  // Initially this is equal to 'csGenesisBlock'.
+  BlockHash current_era_genesis_block = 29;
+  // Time when the current era started.
+  Timestamp current_era_genesis_time = 30;
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -45,9 +45,22 @@ message ModuleRef {
   bytes value = 1;
 }
 
-// Source bytes of a smart contract module.
-message ModuleSource {
-  bytes value = 1;
+// Source bytes of a versioned smart contract module.
+message VersionedModuleSource {
+  // Source bytes of a smart contract v0 module.
+  message ModuleSourceV0 {
+    bytes value = 1;
+  }
+
+  // Source bytes of a smart contract v1 module.
+  message ModuleSourceV1 {
+    bytes value = 1;
+  }
+
+  oneof module {
+    ModuleSourceV0 v0 = 1;
+    ModuleSourceV1 v1 = 2;
+  }
 }
 
 // Unix timestamp in milliseconds.
@@ -132,7 +145,7 @@ message BakerElectionVerifyKey {
 message BakerSignatureVerifyKey {
   bytes value = 1;
 }
- 
+
 // Baker's public key used to check signatures on finalization records.
 // This is only used if the baker has sufficient stake to participate in
 // finalization.
@@ -524,7 +537,7 @@ message InstanceInfo {
   // Version 0 smart contract instance information.
   message V0 {
     // The state of the instance.
-    ContractState model = 1;
+    ContractStateV0 model = 1;
     // The account address which deployed the instance.
     AccountAddress owner = 2;
     // The amount of CCD tokens in the balance of the instance.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -6,12 +6,12 @@ package concordium.v2;
 message Empty {
 }
 
-/// Hash of a block. This is always 32 bytes long.
+// Hash of a block. This is always 32 bytes long.
 message BlockHash {
   bytes value = 1;
 }
 
-/// Hash of a transaction. This is always 32 bytes long.
+// Hash of a transaction. This is always 32 bytes long.
 message TransactionHash {
   bytes value = 1;
 }
@@ -40,13 +40,12 @@ message AccountIndex {
   uint64 value = 1;
 }
 
-// Reference (hash) of a smart contract module. This is always 32 bytes long.
+// A smart contract module reference. This is always 32 bytes long.
 message ModuleRef {
   bytes value = 1;
 }
 
-//! Source bytes of a smart contract module.
-// ok test
+// Source bytes of a smart contract module.
 message ModuleSource {
   bytes value = 1;
 }
@@ -281,7 +280,7 @@ message AccountAddress {
   bytes value = 1;
 }
 
-// An addrass is either a contract or account address.
+// An address of either a contract or an account.
 message Address {
   oneof type {
     AccountAddress account = 1;
@@ -468,7 +467,7 @@ message BlockHashInput {
 // Input to queries which take an account as a parameter.
 message AccountIdentifierInput {
   oneof account_identifier_input {
-    // Address of the account.
+    // Identify the account by the address of the account.
     AccountAddress address = 1;
     // Identify the account by the credential that belongs or has belonged to it.
     CredentialRegistrationId cred_id = 2;
@@ -505,8 +504,7 @@ message AncestorsRequest {
 message ModuleSourceRequest {
   // The block to be used for the query.
   BlockHashInput block_hash = 1;
-
-  // The reference (hash) of the module.
+  // The reference of the module.
   ModuleRef module_ref = 2;
 }
 
@@ -519,45 +517,67 @@ message ContractAddress {
   uint64 subindex = 2;
 }
 
+// Request for getting information about a smart contract instance.
 message InstanceInfoRequest {
+  // The block to be used for the query.
   BlockHashInput block_hash = 1;
+  // The address of the smart contract instance.
   ContractAddress address = 2;
 }
 
 // Information about a smart contract instance.
 message InstanceInfo {
 
+  // Version 0 smart contract instance information.
   message V0 {
+    // The state of the instance.
     ContractState model = 1;
+    // The account address which deployed the instance.
     AccountAddress owner = 2;
+    // The amount of CCD tokens in the balance of the instance.
     Amount amount = 3;
+    // A list of endpoints exposed by the instance.
     repeated ReceiveName methods = 4;
+    // The name of the smart contract of the instance.
     InitName name = 5;
+    // The module reference for the smart contract module of the instance.
     ModuleRef source_module = 6;
   }
 
+  // Version 1 smart contract instance information.
   message V1 {
+    // The account address which deployed the instance.
     AccountAddress owner = 2;
+    // The amount of CCD tokens in the balance of the instance.
     Amount amount = 3;
+    // A list of endpoints exposed by the instance.
     repeated ReceiveName methods = 4;
+    // The name of the smart contract of the instance.
     InitName name = 5;
+    // The module reference for the smart contract module of the instance.
     ModuleRef source_module = 6;
   }
 
+  // The information depends on the smart contract version used by the instance.
   oneof version {
     V0 v0 = 1;
     V1 v1 = 2;
   }
 }
 
+// The receive name of a smart contract function. Expected format: "<contract_name>.<func_name>".
+// It must only consist of atmost 100 ascii alphanumeric or punctuation characters, and must contain a '.'.
 message ReceiveName {
   string value = 1;
 }
 
+// The init name of a smart contract function. Expected format: "init_<contract_name>".
+// It must only consist of atmost 100 ascii alphanumeric or punctuation characters, must not contain a '.' and must start with 'init_'.
 message InitName {
   string value = 1;
 }
 
+// A smart contract v0 state.
 message ContractState {
   bytes value = 1;
 }
@@ -669,15 +689,20 @@ enum TransactionType {
   // TODO: implement rest
 }
 
+// The response for getNextAccountSequenceNumber.
 message NextAccountSequenceNumber {
+  // The best guess for the available account sequence number.
   SequenceNumber sequence_number = 1;
+  // Whether the guess relies on any non-finalized transactions. If true all of the relevant transactions are finalized.
   bool all_final = 2;
 }
 
+// A duration of milliseconds.
 message Duration {
   uint64 value = 1;
 }
 
+// The different versions of the protocol.
 enum ProtocolVersion {
   PROTOCOL_VERSION_1 = 0;
   PROTOCOL_VERSION_2 = 1;
@@ -685,62 +710,67 @@ enum ProtocolVersion {
   PROTOCOL_VERSION_4 = 3;
 }
 
+// The number of chain restarts via a protocol update. An effected
+// protocol update instruction might not change the protocol version
+// specified in the previous field, but it always increments the genesis
+// index.
 message GenesisIndex {
   uint32 value = 1;
 }
 
+// The response for GetConsensusInfo.
 message ConsensusInfo {
-  // Hash of the current best block
+  // Hash of the current best block.
   BlockHash best_block = 1;
-  // Hash of the (original) genesis block
+  // Hash of the (original) genesis block.
   BlockHash genesis_block = 2;
-  // Time of the (original) genesis block
+  // Time of the (original) genesis block.
   Timestamp genesis_time = 3;
-  // (Current) slot duration in milliseconds
+  // (Current) slot duration in milliseconds.
   Duration slot_duration = 4;
-  // (Current) epoch duration in milliseconds
+  // (Current) epoch duration in milliseconds.
   Duration epoch_duration = 5;
-  // Hash of the last finalized block
+  // Hash of the last finalized block.
   BlockHash last_finalized_block = 6;
-  // Absolute height of the best block
+  // Absolute height of the best block.
   AbsoluteBlockHeight best_block_height = 7;
-  // Absolute height of the last finalized block
+  // Absolute height of the last finalized block.
   AbsoluteBlockHeight last_finalized_block_height = 8;
-  // Total number of blocks received
+  // Total number of blocks received.
   uint32 blocks_received_count = 9;
-  // The last time a block was received
+  // The last time a block was received.
   optional Timestamp block_last_received_time = 10;
-  // Moving average latency between a block's slot time and received time
+  // Moving average latency between a block's slot time and received time.
   double block_receive_latency_ema = 11;
-  // Standard deviation of moving average latency between a block's slot time and received time
+  // Standard deviation of moving average latency between a block's slot time and received time.
   double block_receive_latency_emsd = 12;
-  // Moving average time between receiving blocks
+  // Moving average time between receiving blocks.
   optional double block_receive_period_ema = 13;
-  // Standard deviation of moving average time between receiving blocks
+  // Standard deviation of moving average time between receiving blocks.
   optional double block_receive_period_emsd = 14;
-  // Total number of blocks received and verified
+  // Total number of blocks received and verified.
   uint32 blocks_verified_count = 15;
-  // The last time a block was verified (added to the tree)
+  // The last time a block was verified (added to the tree).
   optional Timestamp block_last_arrived_time = 16;
-  // Moving average latency between a block's slot time and its arrival
+  // Moving average latency between a block's slot time and its arrival.
   double block_arrive_latency_ema = 17;
-  // Standard deviation of moving average latency between a block's slot time and its arrival
+  // Standard deviation of moving average latency between a block's slot time and its arrival.
   double block_arrive_latency_emsd = 18;
-  // Moving average time between block arrivals
+  // Moving average time between block arrivals.
   optional double block_arrive_period_ema = 19;
-  // Standard deviation of moving average time between block arrivals
+  // Standard deviation of moving average time between block arrivals.
   optional double block_arrive_period_emsd = 20;
-  // Moving average number of transactions per block
+  // Moving average number of transactions per block.
   double transactions_per_block_ema = 21;
-  // Standard deviation of moving average number of transactions per block
+  // Standard deviation of moving average number of transactions per block.
   double transactions_per_block_emsd = 22;
-  // Number of finalizations
+  // Number of finalizations.
   uint32 finalization_count = 23;
-  // Time of last verified finalization
+  // Time of last verified finalization.
   optional Timestamp last_finalized_time = 24;
-  // Moving average time between finalizations
+  // Moving average time between finalizations.
   optional double finalization_period_ema = 25;
-  // Standard deviation of moving average time between finalizations
+  // Standard deviation of moving average time between finalizations.
   optional double finalization_period_emsd = 26;
   // Currently active protocol version.
   ProtocolVersion protocol_version = 27;

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -437,3 +437,11 @@ message FinalizedBlockInfo {
   // Absolute height of the block, height 0 is the genesis block.
   AbsoluteBlockHeight height = 2;
 }
+
+// Request the ancestors for the given block.
+message AncestorsRequest {
+  // The block to get ancestors of.
+  BlockHashInput block_hash = 1;
+  // The maximum number of ancestors returned.
+  uint64 amount = 2;
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -442,13 +442,17 @@ message BlockHashInput {
   }
 }
 
+message AccountIdentifierInput {
+  oneof account_identifier_input {
+    AccountAddress address = 1;
+    CredentialRegistrationId cred_id = 2;
+    AccountIndex account_index = 3;
+  }
+}
+
 message AccountInfoRequest {
   BlockHashInput block_hash = 1;
-  oneof account_identifier {
-    AccountAddress address = 2;
-    CredentialRegistrationId cred_id = 3;
-    AccountIndex account_index = 4;
-  }
+  AccountIdentifierInput account_identifier = 2;
 }
 
 // Information about a finalized block that is part of the streaming response.
@@ -633,4 +637,9 @@ enum TransactionType {
   UPDATE = 2;
   TRANSFER = 3;
   // TODO: implement rest
+}
+
+message NextAccountNonce {
+  Nonce nonce = 1;
+  bool all_final = 2;
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -265,6 +265,14 @@ message AccountAddress {
   bytes value = 1;
 }
 
+// An addrass is either a contract or account address.
+message Address {
+  oneof type {
+    AccountAddress account = 1;
+    ContractAddress contract = 2;
+  }
+}
+
 // A public key used to verify transaction signatures from an account.
 message AccountVerifyKey {
   oneof key {
@@ -523,13 +531,11 @@ message ContractState {
 message TransactionStatus {
 
   message Committed {
-    Empty outcomes = 1;
-    // map<BlockHash, TransactionSummary> outcomes = 1; // This is Maybe TransactionSummary in hs. Why the maybe?
+    repeated TransactionSummaryInBlock outcomes = 1;
   }
 
   message Finalized {
-    BlockHash block_hash = 1; // Return in metadata instead?
-    TransactionSummary outcome = 2;
+    TransactionSummaryInBlock outcomes = 1; // TODO: Should this also be repeated for when finalization committee is corrupt?
   }
 
   oneof status {
@@ -539,28 +545,68 @@ message TransactionStatus {
   }
 }
 
+message TransactionSummaryInBlock {
+  BlockHash block_hash = 1;
+  optional TransactionSummary outcome = 2; // TODO: This is optional in haskell, why?
+}
+
 message Energy {
   uint64 value = 1;
 }
 
 message TransactionSummary {
   message AccountTransaction {
-    optional TransactionType type = 1; // TODO: Why is this optional in HS?
+    optional TransactionType value = 1; // TODO: Why is this optional in HS?
   }
   message CredentialDeploymentTransaction {
-    CredentialType type = 1;
+    CredentialType value = 1;
   }
   message UpdateTransaction {
-    UpdateType type = 1;
+    UpdateType value = 1;
   }
+  message TransactionIndex {
+    uint64 value = 1;
+  }
+  message Success {
+    message Event {
+      message Transferred {
+        Address sender = 1;
+        Amount amount = 2;
+        Address receiver = 3;
+      }
+      // TODO: implement remaning variants
+      oneof type {
+        Transferred transferred = 1;
+      }
+    }
+    repeated Event events = 1;
+  }
+  message Reject {
+    message RejectReason {
+      Empty value = 1; // TODO: implement
+    }
+    RejectReason reject_reason = 1;
+  }
+
   optional AccountAddress sender = 1;
   TransactionHash hash = 2;
   Amount cost = 3;
   Energy energy_cost = 4;
-
+  oneof type {
+    AccountTransaction account = 5;
+    CredentialDeploymentTransaction credential_deployment = 6;
+    UpdateTransaction update = 7;
+  }
+  oneof result {
+    Success success = 8;
+    Reject reject = 9;
+  }
+  TransactionIndex index = 10;
 }
 
-// TODO: Consider microgtu/euro should be the default value, as it will be used much more frequently.
+
+
+// TODO: Consider if microgtu/euro should be the default value, as it will be used much more frequently.
 // First variant of an enum will be encoded with no bytes.
 enum UpdateType {
     UPDATE_PROTOCOL = 0;
@@ -581,18 +627,10 @@ enum UpdateType {
     UPDATE_TIME_PARAMETERS = 15;
 }
 
-message TransactionType {
-  message ModuleDeploy {
-    ModuleSource module_source = 1;
-  }
-
-  message Transfer {
-    AccountAddress to_address = 1;
-    Amount amount = 2;
-  }
-
-  oneof type {
-    ModuleDeploy module_deploy = 1;
-    Transfer transfer = 4;
-  }
+enum TransactionType {
+  DEPLOY_MODULE = 0;
+  INIT_CONTRACT = 1;
+  UPDATE = 2;
+  TRANSFER = 3;
+  // TODO: implement rest
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -410,13 +410,6 @@ message AccountCredential {
   }
 }
 
-message CredentialType {
-  oneof type {
-    Empty initial = 1;
-    Empty normal = 2;
-  }
-}
-
 // Information about the account at a particular point in time.
 message AccountInfo {
   // Next sequence number to be used for transactions signed from this account.
@@ -582,111 +575,10 @@ message ContractState {
   bytes value = 1;
 }
 
-message TransactionStatus {
-
-  message Committed {
-    repeated TransactionSummaryInBlock outcomes = 1;
-  }
-
-  message Finalized {
-    TransactionSummaryInBlock outcomes = 1; // TODO: Should this also be repeated for when finalization committee is corrupt?
-  }
-
-  oneof status {
-    Empty received = 1;
-    Committed committed = 2;
-    Finalized finalized = 3;
-  }
-}
-
-message TransactionSummaryInBlock {
-  BlockHash block_hash = 1;
-  optional TransactionSummary outcome = 2; // TODO: This is optional in haskell, why?
-}
-
+// Energy is used to count exact execution cost.
+// This cost is then converted to CCD amounts.
 message Energy {
   uint64 value = 1;
-}
-
-message TransactionSummary {
-  message AccountTransaction {
-    optional TransactionType value = 1; // TODO: Why is this optional in HS?
-  }
-  message CredentialDeploymentTransaction {
-    CredentialType value = 1;
-  }
-  message UpdateTransaction {
-    UpdateType value = 1;
-  }
-  message TransactionIndex {
-    uint64 value = 1;
-  }
-  message Success {
-    message Event {
-      message Transferred {
-        Address sender = 1;
-        Amount amount = 2;
-        Address receiver = 3;
-      }
-      // TODO: implement remaning variants
-      oneof type {
-        Transferred transferred = 1;
-      }
-    }
-    repeated Event events = 1;
-  }
-  message Reject {
-    message RejectReason {
-      Empty value = 1; // TODO: implement
-    }
-    RejectReason reject_reason = 1;
-  }
-
-  optional AccountAddress sender = 1;
-  TransactionHash hash = 2;
-  Amount cost = 3;
-  Energy energy_cost = 4;
-  oneof type {
-    AccountTransaction account = 5;
-    CredentialDeploymentTransaction credential_deployment = 6;
-    UpdateTransaction update = 7;
-  }
-  oneof result {
-    Success success = 8;
-    Reject reject = 9;
-  }
-  TransactionIndex index = 10;
-}
-
-
-
-// TODO: Consider if microgtu/euro should be the default value, as it will be used much more frequently.
-// First variant of an enum will be encoded with no bytes.
-enum UpdateType {
-    UPDATE_PROTOCOL = 0;
-    UPDATE_ELECTION_DIFFICULTY = 1;
-    UPDATE_EURO_PER_ENERGY = 2;
-    UPDATE_MICRO_GTU_PER_EURO = 3;
-    UPDATE_FOUNDATION_ACCOUNT = 4;
-    UPDATE_MINT_DISTRIBUTION = 5;
-    UPDATE_TRANSACTION_FEE_DISTRIBUTION = 6;
-    UPDATE_GAS_REWARDS = 7;
-    UPDATE_POOL_PARAMETERS = 8;
-    ADD_ANONYMITY_REVOKER = 9;
-    ADD_IDENTITY_PROVIDER = 10;
-    UPDATE_ROOT_KEYS = 11;
-    UPDATE_LEVEL1_KEYS = 12;
-    UPDATE_LEVEL2_KEYS = 13;
-    UPDATE_COOLDOWN_PARAMETERS = 14;
-    UPDATE_TIME_PARAMETERS = 15;
-}
-
-enum TransactionType {
-  DEPLOY_MODULE = 0;
-  INIT_CONTRACT = 1;
-  UPDATE = 2;
-  TRANSFER = 3;
-  // TODO: implement rest
 }
 
 // The response for getNextAccountSequenceNumber.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -385,6 +385,13 @@ message AccountCredential {
   }
 }
 
+message CredentialType {
+  oneof type {
+    Empty initial = 1;
+    Empty normal = 2;
+  }
+}
+
 message AccountInfo {
   // Next sequence number to be used for transactions signed from this account.
   Nonce nonce = 1;
@@ -511,4 +518,81 @@ message InitName {
 
 message ContractState {
   bytes value = 1;
+}
+
+message TransactionStatus {
+
+  message Committed {
+    Empty outcomes = 1;
+    // map<BlockHash, TransactionSummary> outcomes = 1; // This is Maybe TransactionSummary in hs. Why the maybe?
+  }
+
+  message Finalized {
+    BlockHash block_hash = 1; // Return in metadata instead?
+    TransactionSummary outcome = 2;
+  }
+
+  oneof status {
+    Empty received = 1;
+    Committed committed = 2;
+    Finalized finalized = 3;
+  }
+}
+
+message Energy {
+  uint64 value = 1;
+}
+
+message TransactionSummary {
+  message AccountTransaction {
+    optional TransactionType type = 1; // TODO: Why is this optional in HS?
+  }
+  message CredentialDeploymentTransaction {
+    CredentialType type = 1;
+  }
+  message UpdateTransaction {
+    UpdateType type = 1;
+  }
+  optional AccountAddress sender = 1;
+  TransactionHash hash = 2;
+  Amount cost = 3;
+  Energy energy_cost = 4;
+
+}
+
+// TODO: Consider microgtu/euro should be the default value, as it will be used much more frequently.
+// First variant of an enum will be encoded with no bytes.
+enum UpdateType {
+    UPDATE_PROTOCOL = 0;
+    UPDATE_ELECTION_DIFFICULTY = 1;
+    UPDATE_EURO_PER_ENERGY = 2;
+    UPDATE_MICRO_GTU_PER_EURO = 3;
+    UPDATE_FOUNDATION_ACCOUNT = 4;
+    UPDATE_MINT_DISTRIBUTION = 5;
+    UPDATE_TRANSACTION_FEE_DISTRIBUTION = 6;
+    UPDATE_GAS_REWARDS = 7;
+    UPDATE_POOL_PARAMETERS = 8;
+    ADD_ANONYMITY_REVOKER = 9;
+    ADD_IDENTITY_PROVIDER = 10;
+    UPDATE_ROOT_KEYS = 11;
+    UPDATE_LEVEL1_KEYS = 12;
+    UPDATE_LEVEL2_KEYS = 13;
+    UPDATE_COOLDOWN_PARAMETERS = 14;
+    UPDATE_TIME_PARAMETERS = 15;
+}
+
+message TransactionType {
+  message ModuleDeploy {
+    ModuleSource module_source = 1;
+  }
+
+  message Transfer {
+    AccountAddress to_address = 1;
+    Amount amount = 2;
+  }
+
+  oneof type {
+    ModuleDeploy module_deploy = 1;
+    Transfer transfer = 4;
+  }
 }


### PR DESCRIPTION
## Purpose

Implement some of the new gRPC api v2 functions. https://github.com/Concordium/concordium-node/issues/433
Should be merged with https://github.com/Concordium/concordium-node/pull/482



## Changes

- Extend the gRPC api v2 service with `GetModuleList`, `GetModuleSource`, `GetInstanceList`, `GetInstanceInfo`, `GetNextAccountSequenceNumber`, `GetConsensusInfo`, `GetAncestors` and some initial work for `GetTransactionStatus`.
- Added the relevant types.
- Introduce `AccountIdentifierInput` and updated `AccountInfoRequest` to use it.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

