### PR TITLE
Another round of gRPC v2 api functions

### DIFF
--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -67,4 +67,7 @@ service Queries {
 
   // Get status information about the passive delegators.
   rpc GetPassiveDelegationStatus (BlockHashInput) returns (PassiveDelegationStatus);
+
+  // Get a stream of live blocks at a given height.
+  rpc GetBlocksAtHeight (BlocksAtHeightRequest) returns (stream BlockHash);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -70,4 +70,7 @@ service Queries {
 
   // Get a stream of live blocks at a given height.
   rpc GetBlocksAtHeight (BlocksAtHeightRequest) returns (stream BlockHash);
+
+  // Get status of the tokenomics at the end of a given block.
+  rpc GetTokenomicsStatus (BlockHashInput) returns (TokenomicsStatus);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -62,15 +62,15 @@ service Queries {
   // Get all the bakers at the end of the given block.
   rpc GetBakerList (BlockHashInput) returns (stream BakerId);
 
-  // Get status information about a given pool.
-  rpc GetPoolStatus (PoolStatusRequest) returns (PoolStatus);
+  // Get information about a given pool at the end of a given block.
+  rpc GetPoolInfo (PoolInfoRequest) returns (PoolInfoResponse);
 
-  // Get status information about the passive delegators.
-  rpc GetPassiveDelegationStatus (BlockHashInput) returns (PassiveDelegationStatus);
+  // Get information about the passive delegators at the end of a given block.
+  rpc GetPassiveDelegationInfo (BlockHashInput) returns (PassiveDelegationInfo);
 
-  // Get a stream of live blocks at a given height.
-  rpc GetBlocksAtHeight (BlocksAtHeightRequest) returns (stream BlockHash);
+  // Get a list of live blocks at a given height.
+  rpc GetBlocksAtHeight (BlocksAtHeightRequest) returns (BlocksAtHeightResponse);
 
-  // Get status of the tokenomics at the end of a given block.
-  rpc GetTokenomicsStatus (BlockHashInput) returns (TokenomicsStatus);
+  // Get information about tokenomics at the end of a given block.
+  rpc GetTokenomicsInfo (BlockHashInput) returns (TokenomicsInfo);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -50,6 +50,9 @@ service Queries {
   // Get information of the current state of consensus.
   rpc GetConsensusInfo (Empty) returns (ConsensusInfo);
 
+  // Get the cryptographic parameters in a given block.
+  rpc GetCryptographicParameters (BlockHashInput) returns (CryptographicParameters);
+
   // Get the status of and information about a specific transaction.
   rpc GetTransactionStatus (TransactionHash) returns (TransactionStatus);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -7,7 +7,7 @@ package concordium.v2;
 service Queries {
   // Return a stream of blocks that arrive from the time the query is made onward.
   // This can be used to listen for incoming blocks.
-  rpc GetBlocks (Empty) returns (stream BlockInfo);
+  rpc GetBlocks (Empty) returns (stream ArrivedBlockInfo);
 
   // Return a stream of blocks that are finalized from the time the query is
   // made onward. This can be used to listen for newly finalized blocks. Note
@@ -55,4 +55,7 @@ service Queries {
 
   // Get the cryptographic parameters in a given block.
   rpc GetCryptographicParameters (BlockHashInput) returns (CryptographicParameters);
+
+  // Get information, such as height, timings, and transaction counts for the given block.
+  rpc GetBlockInfo (BlockHashInput) returns (BlockInfo);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -61,4 +61,10 @@ service Queries {
 
   // Get all the bakers at the end of the given block.
   rpc GetBakerList (BlockHashInput) returns (stream BakerId);
+
+  // Get status information about a given pool.
+  rpc GetPoolStatus (PoolStatusRequest) returns (PoolStatus);
+
+  // Get status information about the passive delegators.
+  rpc GetPassiveDelegationStatus (BlockHashInput) returns (PassiveDelegationStatus);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -58,4 +58,7 @@ service Queries {
 
   // Get information, such as height, timings, and transaction counts for the given block.
   rpc GetBlockInfo (BlockHashInput) returns (BlockInfo);
+
+  // Get all the bakers at the end of the given block.
+  rpc GetBakerList (BlockHashInput) returns (stream BakerId);
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -757,3 +757,87 @@ message BlockInfo {
   // The hash of the block state after this block.
   StateHash state_hash = 16;
 }
+
+// Request for GetPoolStatus.
+message PoolStatusRequest {
+  // Block in which to query the pool information.
+  BlockHashInput block_hash = 1;
+  // The 'BakerId' of the pool owner.
+  BakerId baker = 2;
+}
+
+// A pending change to a baker pool.
+message PoolPendingChange {
+  // A reduction in baker equity capital is pending.
+  message Reduce {
+    // New baker equity capital.
+    Amount reduced_equity_capital = 1;
+    // Timestamp when the change takes effect.
+    Timestamp effective_time = 2;
+  }
+
+  // Removal of the pool is pending.
+  message Remove {
+    // Timestamp when the change takes effect.
+    Timestamp effective_time = 1;
+  }
+
+  oneof change {
+    Reduce reduce = 1;
+    Remove remove = 2;
+  }
+}
+
+// Information about the status of a baker pool in the current reward period.
+message PoolCurrentPaydayStatus {
+  // The number of blocks baked in the current reward period.
+  uint64 blocks_baked = 1;
+  // Whether the baker has contributed a finalization proof in the current reward period.
+  bool finalization_live = 2;
+  // The transaction fees accruing to the pool in the current reward period.
+  Amount transaction_fees_earned = 3;
+  // The effective stake of the baker in the current reward period.
+  Amount effective_stake = 4;
+  // The lottery power of the baker in the current reward period.
+  double lottery_power = 5;
+  // The effective equity capital of the baker for the current reward period.
+  Amount baker_equity_capital = 6;
+  // The effective delegated capital to the pool for the current reward period.
+  Amount delegated_capital = 7;
+}
+
+// Status information about a given pool.
+message PoolStatus {
+  // The 'BakerId' of the pool owner.
+  BakerId baker = 1;
+  // The account address of the pool owner.
+  AccountAddress address = 2;
+  // The equity capital provided by the pool owner.
+  Amount equity_capital = 3;
+  // The capital delegated to the pool by other accounts.
+  Amount delegated_capital = 4;
+  // The maximum amount that may be delegated to the pool, accounting for leverage and stake limits.
+  Amount delegated_capital_cap = 5;
+  // The pool info associated with the pool: open status, metadata URL and commission rates.
+  BakerPoolInfo pool_info = 6;
+  // Any pending change to the equity carpital.
+  optional PoolPendingChange equity_pending_change = 7;
+  // Status of the pool in the current reward period.
+  optional PoolCurrentPaydayStatus current_payday_status = 8;
+  // Total capital staked across all pools, including passive delegation.
+  Amount all_pool_total_capital = 9;
+}
+
+// Status information about passive delegators.
+message PassiveDelegationStatus {
+  // The total capital delegated passively.
+  Amount delegated_capital = 1;
+  // The passive delegation commission rates.
+  CommissionRates commission_rates = 2;
+  // The transaction fees accruing to the passive delegators in the current reward period.
+  Amount current_payday_transaction_fees_earned = 3;
+  // The effective delegated capital of passive delegators for the current reward period.
+  Amount current_payday_delegated_capital = 4;
+  // Total capital staked across all pools, including passive delegation.
+  Amount all_pool_total_capital = 5;
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -841,3 +841,28 @@ message PassiveDelegationStatus {
   // Total capital staked across all pools, including passive delegation.
   Amount all_pool_total_capital = 5;
 }
+
+// Request for GetBlocksAtHeight.
+message BlocksAtHeightRequest {
+  // Request using an absolute block height.
+  message Absolute {
+    // The absolute block height.
+    AbsoluteBlockHeight height = 1;
+  }
+
+  // Request using a relative block height.
+  message Relative {
+    // Genesis index to start from.
+    GenesisIndex genesis_index = 1;
+    // Height starting from the genesis block at the genesis index.
+    BlockHeight height = 2;
+    // Whether to return results only from the specified genesis index (`true`),
+    // or allow results from more recent genesis indices as well (`false`).
+    bool restrict = 3;
+  }
+
+  oneof blocks_at_height {
+    Absolute absolute = 1;
+    Relative relative = 2;
+  }
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -866,3 +866,63 @@ message BlocksAtHeightRequest {
     Relative relative = 2;
   }
 }
+
+// A base-10 floating point number representation.
+// The value is `mantissa * 10^(-exponent)`.
+//
+// At least 6 significant figures were required by the specification,
+// and 'uint32' provides 9.  Exponent values greater than about
+// 29 will not be necessary, since such a rate will be effectively
+// 0 (when we compute the amount that is minted based on a 64-bit
+// value as the current number of CCDs.)
+message MintRate {
+  uint32 mantissa = 1;
+  uint32 exponent = 2;
+}
+
+// The status of the tokenomics at the end of a given block.
+message TokenomicsStatus {
+  // Version 0 tokenomics.
+  message V0 {
+    // The total CCD in existence.
+    Amount total_amount = 1;
+    // The total CCD in encrypted balances.
+    Amount total_encrypted_amount = 2;
+    // The amount in the baking reward account.
+    Amount baking_reward_account = 3;
+    // The amount in the finalization reward account.
+    Amount finalization_reward_account = 4;
+    // The amount in the GAS account.
+    Amount gas_account = 5;
+    // The protocol version.
+    ProtocolVersion protocol_version = 6;
+  }
+  // Version 1 tokenomics.
+  message V1 {
+    // The total CCD in existence.
+    Amount total_amount = 1;
+    // The total CCD in encrypted balances.
+    Amount total_encrypted_amount = 2;
+    // The amount in the baking reward account.
+    Amount baking_reward_account = 3;
+    // The amount in the finalization reward account.
+    Amount finalization_reward_account = 4;
+    // The amount in the GAS account.
+    Amount gas_account = 5;
+    // The transaction reward fraction accruing to the foundation (to be paid at next payday).
+    Amount foundation_transaction_rewards = 6;
+    // The time of the next payday.
+    Timestamp next_payday_time = 7;
+    // The rate at which CCD will be minted (as a proportion of the total supply) at the next payday.
+    MintRate next_payday_mint_rate = 8;
+    // The total capital put up as stake by bakers and delegators.
+    Amount total_staked_capital = 9;
+    // The protocol version.
+    ProtocolVersion protocol_version = 10;
+  }
+
+  oneof tokenomics {
+    V0 v0 = 1;
+    V1 v1 = 2;
+  }
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -714,9 +714,11 @@ message CryptographicParameters {
   // A free-form string used to distinguish between different chains even if they share other parameters.
   string genesis_string = 1;
   // Generators for the bulletproofs.
+  // It is a serialized list of 256 group elements in the G1 group of the BLS12-381 curve.
   bytes bulletproof_generators = 2;
   // A shared commitment key known to the chain and the account holder (and therefore it is public).
   // The account holder uses this commitment key to generate commitments to values in the attribute list.
+  // It is a serialized pair of group elements  in the G1 group of the BLS12-381 curve.
   bytes on_chain_commitment_key = 3;
 }
 
@@ -758,8 +760,8 @@ message BlockInfo {
   StateHash state_hash = 16;
 }
 
-// Request for GetPoolStatus.
-message PoolStatusRequest {
+// Request for GetPoolInfo.
+message PoolInfoRequest {
   // Block in which to query the pool information.
   BlockHashInput block_hash = 1;
   // The 'BakerId' of the pool owner.
@@ -788,8 +790,8 @@ message PoolPendingChange {
   }
 }
 
-// Information about the status of a baker pool in the current reward period.
-message PoolCurrentPaydayStatus {
+// Information about a baker pool in the current reward period.
+message PoolCurrentPaydayInfo {
   // The number of blocks baked in the current reward period.
   uint64 blocks_baked = 1;
   // Whether the baker has contributed a finalization proof in the current reward period.
@@ -806,8 +808,9 @@ message PoolCurrentPaydayStatus {
   Amount delegated_capital = 7;
 }
 
-// Status information about a given pool.
-message PoolStatus {
+// Type for the response of GetPoolInfo.
+// Contains information about a given pool at the end of a given block.
+message PoolInfoResponse {
   // The 'BakerId' of the pool owner.
   BakerId baker = 1;
   // The account address of the pool owner.
@@ -822,14 +825,15 @@ message PoolStatus {
   BakerPoolInfo pool_info = 6;
   // Any pending change to the equity carpital.
   optional PoolPendingChange equity_pending_change = 7;
-  // Status of the pool in the current reward period.
-  optional PoolCurrentPaydayStatus current_payday_status = 8;
+  // Information of the pool in the current reward period.
+  optional PoolCurrentPaydayInfo current_payday_info = 8;
   // Total capital staked across all pools, including passive delegation.
   Amount all_pool_total_capital = 9;
 }
 
-// Status information about passive delegators.
-message PassiveDelegationStatus {
+// Type for the response of GetPassiveDelegationInfo.
+// Contains information about passive delegators at the end of a given block.
+message PassiveDelegationInfo {
   // The total capital delegated passively.
   Amount delegated_capital = 1;
   // The passive delegation commission rates.
@@ -867,6 +871,12 @@ message BlocksAtHeightRequest {
   }
 }
 
+// Response for GetBlocksAtHeight.
+message BlocksAtHeightResponse {
+  // Live blocks at the given height.
+  repeated BlockHash blocks = 1;
+}
+
 // A base-10 floating point number representation.
 // The value is `mantissa * 10^(-exponent)`.
 //
@@ -880,8 +890,9 @@ message MintRate {
   uint32 exponent = 2;
 }
 
-// The status of the tokenomics at the end of a given block.
-message TokenomicsStatus {
+// Type for the response of GetTokenomicsInfo.
+// Contains information related to tokenomics at the end of a given block.
+message TokenomicsInfo {
   // Version 0 tokenomics.
   message V0 {
     // The total CCD in existence.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -793,3 +793,14 @@ message BlockInfo {
   // Absolute height of the block, height 0 is the genesis block.
   AbsoluteBlockHeight height = 2;
 }
+
+// The response for GetCryptographicParameters.
+message CryptographicParameters {
+  // A free-form string used to distinguish between different chains even if they share other parameters.
+  string genesis_string = 1;
+  // Generators for the bulletproofs.
+  bytes bulletproof_generators = 2;
+  // A shared commitment key known to the chain and the account holder (and therefore it is public).
+  // The account holder uses this commitment key to generate commitments to values in the attribute list.
+  bytes on_chain_commitment_key = 3;
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -16,6 +16,11 @@ message TransactionHash {
   bytes value = 1;
 }
 
+// Hash of the state after some block. This is always 32 bytes long.
+message StateHash {
+  bytes value = 1;
+}
+
 // The absolute height of a block. This is the number of ancestors of a block
 // since the genesis block. In particular, the chain genesis block has absolute
 // height 0.
@@ -594,6 +599,11 @@ message Energy {
   uint64 value = 1;
 }
 
+// A number representing a slot for baking a block.
+message Slot {
+  uint64 value = 1;
+}
+
 // The response for getNextAccountSequenceNumber.
 message NextAccountSequenceNumber {
   // The best guess for the available account sequence number.
@@ -692,7 +702,7 @@ message ConsensusInfo {
 }
 
 // Information about an arrived block that is part of the streaming response.
-message BlockInfo {
+message ArrivedBlockInfo {
   // Hash of the block.
   BlockHash hash = 1;
   // Absolute height of the block, height 0 is the genesis block.
@@ -708,4 +718,42 @@ message CryptographicParameters {
   // A shared commitment key known to the chain and the account holder (and therefore it is public).
   // The account holder uses this commitment key to generate commitments to values in the attribute list.
   bytes on_chain_commitment_key = 3;
+}
+
+// The response for GetBlockInfo.
+message BlockInfo {
+  // Hash of the block.
+  BlockHash hash = 1;
+  // Absolute height of the block, height 0 is the genesis block.
+  AbsoluteBlockHeight height = 2;
+  // The parent block hash. For a re-genesis block, this will be the terminal block of the
+  // previous chain. For the initial genesis block, this will be the hash of the block itself.
+  BlockHash parent_block = 3;
+  // The last finalized block when this block was baked.
+  BlockHash last_finalized_block = 4;
+  // The genesis index for this block. This counts the number of protocol updates that have
+  // preceded this block, and defines the era of the block.
+  GenesisIndex genesis_index = 5;
+  // The height of this block relative to the (re)genesis block of its era.
+  BlockHeight era_block_height = 6;
+  // The time the block was received.
+  Timestamp receive_time = 7;
+  // The time the block was verified.
+  Timestamp arrive_time = 8;
+  // The slot number in which the block was baked.
+  Slot slot_number = 9;
+  // The time of the slot in which the block was baked.
+  Timestamp slot_time = 10;
+  // The baker id of account baking this block. Not provided for a genesis block.
+  optional BakerId baker = 11;
+  // Whether the block is finalized.
+  bool finalized = 12;
+  // The number of transactions in the block.
+  uint32 transaction_count = 13;
+  // The energy cost of the transactions in the block.
+  Energy transactions_energy_cost = 14;
+  // The total byte size of all transactions in the block.
+  uint32 transactions_size = 15;
+  // The hash of the block state after this block.
+  StateHash state_hash = 16;
 }


### PR DESCRIPTION
## Purpose

Adding more functions to gRPC v2 API.
Related to https://github.com/Concordium/concordium-node/pull/494.

## Changes

- Extend gRPC api v2 with `GetCryptographicParameters`, `GetBlockInfo`, `GetBakerList`, `GetPoolStatus`, `GetPassiveDelegationStatus`, `GetBlocksAtHeight` and `GetTokenomicsStatus`.
- Renamed `BlockInfo` type used in `GetBlocks` to `ArrivedBlockInfo`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
