### PR TITLE
Add getters for delegators and branches in v2

### DIFF
--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -90,11 +90,14 @@ service Queries {
   // the end of the given block.
   rpc InvokeInstance (InvokeInstanceRequest) returns (InvokeInstanceResponse);
 
-  // Get the pool delegators of a given pool at the end of a given block.
+  // Get the delegators of a given pool at the end of a given block.
+  // In contrast to the `GetPoolDelegatorsRewardPeriod` which returns delegators that are fixed for the reward period
+  // of the block, this endpoint returns the list of delegators that are registered in the block. Any changes to delegators
+  // are immediately visible in this list.
   // The stream will end when all the delegators has been returned.
   rpc GetPoolDelegators (GetPoolDelegatorsRequest) returns (stream PoolDelegator);
 
-  // Get the reward period pool delegators of a given pool at the end of a given block.
+  // Get the reward period delegators of a given pool at the end of a given block.
   // The stream will end when all the delegators has been returned.
   rpc GetPoolDelegatorsRewardPeriod (GetPoolDelegatorsRewardPeriodRequest) returns (stream PoolDelegatorRewardPeriod);
 

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -106,4 +106,6 @@ service Queries {
   // The stream will end when all the delegators has been returned.
   rpc GetPassiveDelegatorsRewardPeriod (BlockHashInput) returns (stream PoolDelegatorRewardPeriod);
 
+  // Get the current branches of blocks starting and including from the last finalized block.
+  rpc GetBranches (Empty) returns (Branch);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -89,4 +89,21 @@ service Queries {
   // Run the smart contract entrypoint in a given context and in the state at
   // the end of the given block.
   rpc InvokeInstance (InvokeInstanceRequest) returns (InvokeInstanceResponse);
+
+  // Get the pool delegators of a given pool at the end of a given block.
+  // The stream will end when all the delegators has been returned.
+  rpc GetPoolDelegators (GetPoolDelegatorsRequest) returns (stream PoolDelegator);
+
+  // Get the reward period pool delegators of a given pool at the end of a given block.
+  // The stream will end when all the delegators has been returned.
+  rpc GetPoolDelegatorsRewardPeriod (GetPoolDelegatorsRewardPeriodRequest) returns (stream PoolDelegatorRewardPeriod);
+
+  // Get the passive delegators at the end of a given block.
+  // The stream will end when all the delegators has been returned.
+  rpc GetPassiveDelegators (BlockHashInput) returns (stream PoolDelegator);
+
+  // Get the reward period passive delegators at the end of a given block.
+  // The stream will end when all the delegators has been returned.
+  rpc GetPassiveDelegatorsRewardPeriod (BlockHashInput) returns (stream PoolDelegatorRewardPeriod);
+
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -103,7 +103,7 @@ service Queries {
   // for the given block, this endpoint returns the fixed delegators contributing
   // stake in the reward period containing the given block.
   // The stream will end when all the delegators has been returned.
-  rpc GetPoolDelegatorsRewardPeriod (GetPoolDelegatorsRewardPeriodRequest) returns (stream DelegatorRewardPeriodInfo);
+  rpc GetPoolDelegatorsRewardPeriod (GetPoolDelegatorsRequest) returns (stream DelegatorRewardPeriodInfo);
 
   // Get the registered passive delegators at the end of a given block.
   // In contrast to the `GetPassiveDelegatorsRewardPeriod` which returns delegators
@@ -120,6 +120,6 @@ service Queries {
   // The stream will end when all the delegators has been returned.
   rpc GetPassiveDelegatorsRewardPeriod (BlockHashInput) returns (stream DelegatorRewardPeriodInfo);
 
-  // Get the current branches of blocks starting and including from the last finalized block.
+  // Get the current branches of blocks starting from and including the last finalized block.
   rpc GetBranches (Empty) returns (Branch);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -90,24 +90,35 @@ service Queries {
   // the end of the given block.
   rpc InvokeInstance (InvokeInstanceRequest) returns (InvokeInstanceResponse);
 
-  // Get the delegators of a given pool at the end of a given block.
-  // In contrast to the `GetPoolDelegatorsRewardPeriod` which returns delegators that are fixed for the reward period
-  // of the block, this endpoint returns the list of delegators that are registered in the block. Any changes to delegators
+  // Get the registered delegators of a given pool at the end of a given block.
+  // In contrast to the `GetPoolDelegatorsRewardPeriod` which returns delegators
+  // that are fixed for the reward period of the block, this endpoint returns the
+  // list of delegators that are registered in the block. Any changes to delegators
   // are immediately visible in this list.
   // The stream will end when all the delegators has been returned.
-  rpc GetPoolDelegators (GetPoolDelegatorsRequest) returns (stream PoolDelegator);
+  rpc GetPoolDelegators (GetPoolDelegatorsRequest) returns (stream DelegatorInfo);
 
-  // Get the reward period delegators of a given pool at the end of a given block.
+  // Get the fixed delegators of a given pool for the reward period of the given block.
+  // In contracts to the `GetPoolDelegators` which returns delegators registered
+  // for the given block, this endpoint returns the fixed delegators contributing
+  // stake in the reward period containing the given block.
   // The stream will end when all the delegators has been returned.
-  rpc GetPoolDelegatorsRewardPeriod (GetPoolDelegatorsRewardPeriodRequest) returns (stream PoolDelegatorRewardPeriod);
+  rpc GetPoolDelegatorsRewardPeriod (GetPoolDelegatorsRewardPeriodRequest) returns (stream DelegatorRewardPeriodInfo);
 
-  // Get the passive delegators at the end of a given block.
+  // Get the registered passive delegators at the end of a given block.
+  // In contrast to the `GetPassiveDelegatorsRewardPeriod` which returns delegators
+  // that are fixed for the reward period of the block, this endpoint returns the
+  // list of delegators that are registered in the block. Any changes to delegators
+  // are immediately visible in this list.
   // The stream will end when all the delegators has been returned.
-  rpc GetPassiveDelegators (BlockHashInput) returns (stream PoolDelegator);
+  rpc GetPassiveDelegators (BlockHashInput) returns (stream DelegatorInfo);
 
-  // Get the reward period passive delegators at the end of a given block.
+  // Get the fixed passive delegators for the reward period of the given block.
+  // In contracts to the `GetPassiveDelegators` which returns delegators registered
+  // for the given block, this endpoint returns the fixed delegators contributing
+  // stake in the reward period containing the given block.
   // The stream will end when all the delegators has been returned.
-  rpc GetPassiveDelegatorsRewardPeriod (BlockHashInput) returns (stream PoolDelegatorRewardPeriod);
+  rpc GetPassiveDelegatorsRewardPeriod (BlockHashInput) returns (stream DelegatorRewardPeriodInfo);
 
   // Get the current branches of blocks starting and including from the last finalized block.
   rpc GetBranches (Empty) returns (Branch);

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -194,7 +194,7 @@ message StakePendingChange {
     // Unix timestamp in milliseconds when the change takes effect.
     Timestamp effective_time = 2;
   }
-  
+
   oneof change {
     Reduce reduce = 1;
     // Remove the stake. The value is a Unix timestamp of the effective time in
@@ -2097,4 +2097,38 @@ message InvokeInstanceResponse {
     Success success = 1;
     Failure failure = 2;
   }
+}
+
+// Request for GetPoolDelegators.
+message GetPoolDelegatorsRequest {
+  // Block in which to query the delegators.
+  BlockHashInput block_hash = 1;
+  // The 'BakerId' of the pool owner.
+  BakerId baker = 2;
+}
+
+// Request for GetPoolDelegatorsRewardPeriod.
+message GetPoolDelegatorsRewardPeriodRequest {
+  // Block in which to query the delegators.
+  BlockHashInput block_hash = 1;
+  // The 'BakerId' of the pool owner.
+  BakerId baker = 2;
+}
+
+// Stream item for GetPoolDelegators.
+message PoolDelegator {
+  // The delegator account address.
+  AccountAddress account = 1;
+  // The amount of stake currently staked to the pool.
+  Amount stake = 2;
+  // Pending change to the current stake of the delegator.
+  optional StakePendingChange pending_change = 3;
+}
+
+// Stream item for GetPoolDelegators.
+message PoolDelegatorRewardPeriod {
+  // The delegator account address.
+  AccountAddress account = 1;
+  // The amount of stake currently staked to the pool.
+  Amount stake = 2;
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2115,8 +2115,8 @@ message GetPoolDelegatorsRewardPeriodRequest {
   BakerId baker = 2;
 }
 
-// Stream item for GetPoolDelegators.
-message PoolDelegator {
+// Stream item for GetPoolDelegators and GetPassiveDelegators.
+message DelegatorInfo {
   // The delegator account address.
   AccountAddress account = 1;
   // The amount of stake currently staked to the pool.
@@ -2125,8 +2125,8 @@ message PoolDelegator {
   optional StakePendingChange pending_change = 3;
 }
 
-// Stream item for GetPoolDelegators.
-message PoolDelegatorRewardPeriod {
+// Stream item for GetPoolDelegatorsRewardPeriod and GetPassiveDelegatorsRewardPeriod.
+message DelegatorRewardPeriodInfo {
   // The delegator account address.
   AccountAddress account = 1;
   // The amount of stake currently staked to the pool.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2132,3 +2132,11 @@ message PoolDelegatorRewardPeriod {
   // The amount of stake currently staked to the pool.
   Amount stake = 2;
 }
+
+// Response type for GetBranches.
+message Branch {
+  // The hash of the block.
+  BlockHash block_hash = 1;
+  // Further blocks branching of this block.
+  repeated Branch children = 2;
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2099,16 +2099,8 @@ message InvokeInstanceResponse {
   }
 }
 
-// Request for GetPoolDelegators.
+// Request for GetPoolDelegators and GetPoolDelegatorsRewardPeriod.
 message GetPoolDelegatorsRequest {
-  // Block in which to query the delegators.
-  BlockHashInput block_hash = 1;
-  // The 'BakerId' of the pool owner.
-  BakerId baker = 2;
-}
-
-// Request for GetPoolDelegatorsRewardPeriod.
-message GetPoolDelegatorsRewardPeriodRequest {
   // Block in which to query the delegators.
   BlockHashInput block_hash = 1;
   // The 'BakerId' of the pool owner.


### PR DESCRIPTION
## Purpose

Add getter functions for delegators and for branches in v2.

Related to https://github.com/Concordium/concordium-node/pull/513 and https://github.com/Concordium/concordium-rust-sdk/pull/43

## Changes

- Add `GetPoolDelegators`, `GetPoolDelegatorsRewardPeriod`, `GetPassiveDelegators`, `GetPassiveDelegatorsRewardPeriod` and `GetBranches`.

