### PR TITLE
API v2 Getters for info about election, IP, AR and nonfinal tx

### DIFF
--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -129,4 +129,8 @@ service Queries {
   // Get the identity providers registered as of the end of a given block.
   // The stream will end when all the identity providers have been returned.
   rpc GetIdentityProviders (BlockHashInput) returns (stream IpInfo);
+
+  // Get the anonymity revokers registered as of the end of a given block.
+  // The stream will end when all the anonymity revokers have been returned.
+  rpc GetAnonymityRevokers (BlockHashInput) returns (stream ArInfo);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -122,4 +122,7 @@ service Queries {
 
   // Get the current branches of blocks starting from and including the last finalized block.
   rpc GetBranches (Empty) returns (Branch);
+
+  // Get information related to the baker election for a particular block.
+  rpc GetElectionInfo (BlockHashInput) returns (ElectionInfo);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -125,4 +125,8 @@ service Queries {
 
   // Get information related to the baker election for a particular block.
   rpc GetElectionInfo (BlockHashInput) returns (ElectionInfo);
+
+  // Get the identity providers registered as of the end of a given block.
+  // The stream will end when all the identity providers have been returned.
+  rpc GetIdentityProviders (BlockHashInput) returns (stream IpInfo);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -133,4 +133,10 @@ service Queries {
   // Get the anonymity revokers registered as of the end of a given block.
   // The stream will end when all the anonymity revokers have been returned.
   rpc GetAnonymityRevokers (BlockHashInput) returns (stream ArInfo);
+
+  // Get a list of non-finalized transaction hashes for a given account.
+  // This endpoint is not expected to return a large amount of data, but is streaming
+  // for API consistency.
+  // The stream will end when all the non-finalized transaction hashes have been returned.
+  rpc GetAccountNonFinalizedTransactions (AccountAddress) returns (stream TransactionHash);
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2132,3 +2132,30 @@ message Branch {
   // Further blocks branching of this block.
   repeated Branch children = 2;
 }
+
+// The leadership election nonce is an unpredictable value updated once an
+// epoch to make sure that bakers cannot predict too far in the future when
+// they will win blocks.
+message LeadershipElectionNonce {
+  bytes value = 1;
+}
+
+// Response type for GetElectionInfo.
+// Contains information related to baker election for a perticular block.
+message ElectionInfo {
+  message Baker {
+    // The ID of the baker.
+    BakerId baker = 1;
+    // The account address of the baker.
+    AccountAddress account = 2;
+    // The approximate lottery power of the baker.
+    double lottery_power = 3;
+  }
+
+  // Baking lottery election difficulty.
+  ElectionDifficulty election_difficulty = 1;
+  // Current leadership election nonce for the lottery.
+  LeadershipElectionNonce election_nonce = 2;
+  // List of the currently eligible bakers.
+  repeated Baker baker_election_info = 3;
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2135,7 +2135,7 @@ message Branch {
 
 // The leadership election nonce is an unpredictable value updated once an
 // epoch to make sure that bakers cannot predict too far in the future when
-// they will win blocks.
+// they will win the right to bake blocks.
 message LeadershipElectionNonce {
   bytes value = 1;
 }
@@ -2148,7 +2148,7 @@ message ElectionInfo {
     BakerId baker = 1;
     // The account address of the baker.
     AccountAddress account = 2;
-    // The approximate lottery power of the baker.
+    // The lottery power of the baker, rounded to the nearest representable "double".
     double lottery_power = 3;
   }
 


### PR DESCRIPTION
## Purpose

Implement more of API v2.
Related issue https://github.com/Concordium/concordium-node/issues/433.
Should be merged with https://github.com/Concordium/concordium-node/pull/521.

## Changes

- `GetElectionInfo`, `GetIdentityProvidersV2`, `GetAnonymityRevokers` and `GetAccountNonFinalizedTransactions`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
