### PR TITLE
Support for smart contract upgrades.

### DIFF
--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -947,6 +947,16 @@ message ContractTraceElement {
     bool success = 2;
   }
 
+  // A previously interrupted contract was resumed.
+  message Upgraded {
+    // The that was upgraded.
+    ContractAddress address = 1;
+    // The module from which the contract was upgraded.
+    ModuleRef from = 2;
+    // The module to which it was upgraded.
+    ModuleRef to = 3;
+  }
+
   oneof element {
     // A contract instance was updated.
     InstanceUpdatedEvent updated = 1;
@@ -957,6 +967,8 @@ message ContractTraceElement {
     Interrupted interrupted = 3;
     // A previously interrupted contract was resumed.
     Resumed resumed = 4;
+    // A contract was upgraded.
+    Upgraded upgraded = 5;
   }
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -882,11 +882,11 @@ message RejectReason {
     // The pool is not open to delegators.
     Empty pool_closed = 54;
     // The contract upgrade failed because of an invalid module reference
-    UpgradeInvalidModuleReference upgradeInvalidModuleReference = 55;
+    UpgradeInvalidModuleReference upgrade_invalid_module_reference = 55;
     // The contract upgrade failed because the new module did not have a corresponding contract name.
-    UpgradeInvalidContractName upgradeInvalidContractName = 56;
+    UpgradeInvalidContractName upgrade_invalid_contract_name = 56;
     // The contract upgrade failed because the new module does not support contract upgrades.
-    UpgradeInvalidVersion upgradeInvalidVersion = 57;
+    UpgradeInvalidVersion upgrade_invalid_version = 57;
   }
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -739,6 +739,20 @@ message RejectReason {
     repeated CredentialRegistrationId ids = 1;
   }
 
+  message UpgradeInvalidVersion {
+    ModuleRef module_ref = 1;
+    ContractVersion version = 2;
+  }
+
+  message UpgradeInvalidModuleReference {
+    ModuleRef module_ref = 1;
+  }
+
+  message UpgradeInvalidContractName {
+    ModuleRef module_ref = 1;
+    InitName init_name = 2;
+  }
+
   oneof reason {
     // Raised while validating a Wasm module that is not well formed.
     Empty module_not_wf = 1;
@@ -867,6 +881,12 @@ message RejectReason {
     Empty pool_would_become_over_delegated = 53;
     // The pool is not open to delegators.
     Empty pool_closed = 54;
+    // The contract upgrade failed because of an invalid module reference
+    UpgradeInvalidModuleReference upgradeInvalidModuleReference = 55;
+    // The contract upgrade failed because the new module did not have a corresponding contract name.
+    UpgradeInvalidContractName upgradeInvalidContractName = 56;
+    // The contract upgrade failed because the new module does not support contract upgrades.
+    UpgradeInvalidVersion upgradeInvalidVersion = 57;
   }
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -739,37 +739,37 @@ message RejectReason {
     repeated CredentialRegistrationId ids = 1;
   }
 
-  /// A reject reason indicating that a 
-  /// contract upgrade could not be carried out 
-  /// because the desired module did not exist on chain.
+  // A reject reason indicating that a 
+  // contract upgrade could not be carried out 
+  // because the desired module did not exist on chain.
   message UpgradeInvalidModuleReference {
-    /// The module reference that the contract
-    /// tried to upgrade to.
+    // The module reference that the contract
+    // tried to upgrade to.
     ModuleRef module_ref = 1;
   }
 
-  /// A reject reason that is returned when 
-  /// a contract could not be upgraded because 
-  /// the desired module did not contain a 
-  /// contract with the required name.     
+  // A reject reason that is returned when 
+  // a contract could not be upgraded because 
+  // the desired module did not contain a 
+  // contract with the required name.     
   message UpgradeInvalidContractName {
-    /// The module reference that the contract 
-    /// tried to upgrade to.
+    // The module reference that the contract 
+    // tried to upgrade to.
     ModuleRef module_ref = 1;
-    /// The init name of the contract 
-    /// that was tried to upgrade from.
+    // The init name of the contract 
+    // that was tried to upgrade from.
     InitName init_name = 2;
   }
 
-  /// A reject reason that is returned when 
-  /// a contract could not be upgraded due to 
-  /// an incompatible module version.
+  // A reject reason that is returned when 
+  // a contract could not be upgraded due to 
+  // an incompatible module version.
   message UpgradeInvalidVersion {
-    /// The module reference that the contract 
-    /// tried to upgrade to.
+    // The module reference that the contract 
+    // tried to upgrade to.
     ModuleRef module_ref = 1;
-    /// The contract version of the module 
-    /// that was incompatible.
+    // The contract version of the module 
+    // that was incompatible.
     ContractVersion version = 2;
   }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -739,40 +739,6 @@ message RejectReason {
     repeated CredentialRegistrationId ids = 1;
   }
 
-  // A reject reason indicating that a 
-  // contract upgrade could not be carried out 
-  // because the desired module did not exist on chain.
-  message UpgradeInvalidModuleReference {
-    // The module reference that the contract
-    // tried to upgrade to.
-    ModuleRef module_ref = 1;
-  }
-
-  // A reject reason that is returned when 
-  // a contract could not be upgraded because 
-  // the desired module did not contain a 
-  // contract with the required name.     
-  message UpgradeInvalidContractName {
-    // The module reference that the contract 
-    // tried to upgrade to.
-    ModuleRef module_ref = 1;
-    // The init name of the contract 
-    // that was tried to upgrade from.
-    InitName init_name = 2;
-  }
-
-  // A reject reason that is returned when 
-  // a contract could not be upgraded due to 
-  // an incompatible module version.
-  message UpgradeInvalidVersion {
-    // The module reference that the contract 
-    // tried to upgrade to.
-    ModuleRef module_ref = 1;
-    // The contract version of the module 
-    // that was incompatible.
-    ContractVersion version = 2;
-  }
-
   oneof reason {
     // Raised while validating a Wasm module that is not well formed.
     Empty module_not_wf = 1;
@@ -901,12 +867,6 @@ message RejectReason {
     Empty pool_would_become_over_delegated = 53;
     // The pool is not open to delegators.
     Empty pool_closed = 54;
-    // The contract upgrade failed because the desired module does not exist.
-    UpgradeInvalidModuleReference upgrade_invalid_module_reference = 55;
-    // The contract upgrade failed because the required contract did not exist in the desired smart contract module.
-    UpgradeInvalidContractName upgrade_invalid_contract_name = 56;
-    // The contract upgrade failed because the desired module has an incompatible contract version.
-    UpgradeInvalidVersion upgrade_invalid_version = 57;
   }
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -739,18 +739,38 @@ message RejectReason {
     repeated CredentialRegistrationId ids = 1;
   }
 
-  message UpgradeInvalidVersion {
-    ModuleRef module_ref = 1;
-    ContractVersion version = 2;
-  }
-
+  /// A reject reason indicating that a 
+  /// contract upgrade could not be carried out 
+  /// because the desired module did not exist on chain.
   message UpgradeInvalidModuleReference {
+    /// The module reference that the contract
+    /// tried to upgrade to.
     ModuleRef module_ref = 1;
   }
 
+  /// A reject reason that is returned when 
+  /// a contract could not be upgraded because 
+  /// the desired module did not contain a 
+  /// contract with the required name.     
   message UpgradeInvalidContractName {
+    /// The module reference that the contract 
+    /// tried to upgrade to.
     ModuleRef module_ref = 1;
+    /// The init name of the contract 
+    /// that was tried to upgrade from.
     InitName init_name = 2;
+  }
+
+  /// A reject reason that is returned when 
+  /// a contract could not be upgraded due to 
+  /// an incompatible module version.
+  message UpgradeInvalidVersion {
+    /// The module reference that the contract 
+    /// tried to upgrade to.
+    ModuleRef module_ref = 1;
+    /// The contract version of the module 
+    /// that was incompatible.
+    ContractVersion version = 2;
   }
 
   oneof reason {
@@ -881,11 +901,11 @@ message RejectReason {
     Empty pool_would_become_over_delegated = 53;
     // The pool is not open to delegators.
     Empty pool_closed = 54;
-    // The contract upgrade failed because of an invalid module reference
+    // The contract upgrade failed because the desired module does not exist.
     UpgradeInvalidModuleReference upgrade_invalid_module_reference = 55;
-    // The contract upgrade failed because the new module did not have a corresponding contract name.
+    // The contract upgrade failed because the required contract did not exist in the desired smart contract module.
     UpgradeInvalidContractName upgrade_invalid_contract_name = 56;
-    // The contract upgrade failed because the new module does not support contract upgrades.
+    // The contract upgrade failed because the desired module has an incompatible contract version.
     UpgradeInvalidVersion upgrade_invalid_version = 57;
   }
 }


### PR DESCRIPTION
## Purpose

Introduce the new reject reasons related to SC upgrading.

## Changes
Added the following types to the set of possible reject reasons. 

- UpgradeInvalidModuleReference
The contract upgrade failed because of an invalid module reference
- UpgradeInvalidContractName
The contract upgrade failed because the new module did not have a corresponding contract name.
- UpgradeInvalidVersion
The contract upgrade failed because the new module does not support contract upgrades.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

