### PR TITLE
Basic support for P6

### DIFF
--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1785,6 +1785,7 @@ enum ProtocolVersion {
   PROTOCOL_VERSION_3 = 2;
   PROTOCOL_VERSION_4 = 3;
   PROTOCOL_VERSION_5 = 4;
+  PROTOCOL_VERSION_6 = 5;
 }
 
 // The number of chain restarts via a protocol update. An effected


### PR DESCRIPTION
## Purpose

Basic support for the P6 variant. 

Addresses: https://github.com/Concordium/concordium-node/issues/636

## Changes

Added a P6 to the protocol version enum.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
