### PR TITLE
Chain parameters v2

### DIFF
--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2963,8 +2963,10 @@ message ChainParameters {
   oneof parameters {
     // Chain parameters that apply when the block is a protocol version 1-3 block.
     ChainParametersV0 v0 = 1;
-    // Chain parameters that apply when the block is a protocol version 4 or up block.
+    // Chain parameters that apply when the block is a protocol version 4-5 block.
     ChainParametersV1 v1 = 2;
+    // Chain parameters that apply when the block is a protocol version 6- block.
+    ChainParametersV2 v2 = 3;
   }
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2880,7 +2880,7 @@ message ChainParametersV0 {
   // Current transaction fee distribution.
   TransactionFeeDistribution transaction_fee_distribution = 7;
   // Current gas reward parameters.
-  GasRewardsCpv0 gas_rewards = 8;
+  GasRewards gas_rewards = 8;
   // The foundation account.
   AccountAddress foundation_account = 9;
   // Minimum threshold for becoming a baker.
@@ -2915,7 +2915,7 @@ message ChainParametersV1 {
   // Current transaction fee distribution.
   TransactionFeeDistribution transaction_fee_distribution = 8;
   // Current gas reward parameters.
-  GasRewardsCpv0 gas_rewards = 9;
+  GasRewards gas_rewards = 9;
   // The foundation account.
   AccountAddress foundation_account = 10;
   // Parameters governing baking pools and their commissions.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1304,6 +1304,26 @@ message ElectionDifficulty {
   AmountFraction value = 1;
 }
 
+// Parameters that determine timeouts in the consensus protocol used from protocol version 6.
+message TimeoutParameters {
+  // The base value for triggering a timeout
+  Duration timeout_base = 1;
+  // Factor for increasing the timeout. Must be greater than 1.
+  Ratio timeout_increase = 2;
+  // Factor for decreasing the timeout. Must be between 0 and 1.
+  Ratio timeout_decrease = 3;
+}
+
+// Parameters for the consensus protocol used from protocol version 6.
+message ConsensusParametersV1 {
+  // Parameters controlling round timeouts.
+  TimeoutParameters timeout_parameters = 1;
+  // Minimum time interval between blocks.
+  Duration min_block_time = 2;
+  // Maximum energy allowed per block.
+  Energy block_energy_limit = 3;
+}
+
 // Represents an exchange rate.
 message ExchangeRate {
   Ratio value = 1;
@@ -1361,8 +1381,9 @@ message AuthorizationsV0 {
   AccessStructure emergency = 2;
   // New protocol update keys.
   AccessStructure protocol = 3;
-  // Access structure for updating the election difficulty.
-  AccessStructure parameter_election_difficulty = 4;
+  // Access structure for updating the consensus parameters.
+  // Previously, this was the election difficulty.
+  AccessStructure parameter_consensus = 4;
   // Access structure for updating the euro per energy.
   AccessStructure parameter_euro_per_energy = 5;
   // Access structure for updating the micro CCD per euro.
@@ -1578,12 +1599,22 @@ message TransactionFeeDistribution {
   AmountFraction gas_account = 2;
 }
 
-// Distribution of gas rewards.
-message GasRewards {
+// Distribution of gas rewards for chain parameters version 0 and 1.
+message GasRewardsCpv0 {
   // The fraction paid to the baker.
   AmountFraction baker = 1;
   // Fraction paid for including a finalization proof in a block.
   AmountFraction finalization_proof = 2;
+  // Fraction paid for including each account creation transaction in a block.
+  AmountFraction account_creation = 3;
+  // Fraction paid for including an update transaction in a block.
+  AmountFraction chain_update = 4;
+}
+
+// Distribution of gas rewards for chain parameters version 2.
+message GasRewardsCpv2 {
+  // The fraction paid to the baker.
+  AmountFraction baker = 1;
   // Fraction paid for including each account creation transaction in a block.
   AmountFraction account_creation = 3;
   // Fraction paid for including an update transaction in a block.
@@ -1642,7 +1673,7 @@ message UpdatePayload {
     // The transaction fee distribtuion was updated.
     TransactionFeeDistribution transaction_fee_distribution_update = 7;
     // The gas rewards were updated.
-    GasRewards gas_rewards_update = 8;
+    GasRewardsCpv0 gas_rewards_cpv_0_update = 8;
     // The minimum amount of CCD needed to be come a baker was updated.
     BakerStakeThreshold baker_stake_threshold_update = 9;
     // The root keys were updated.
@@ -1661,6 +1692,14 @@ message UpdatePayload {
     TimeParametersCpv1 time_parameters_cpv_1_update = 16;
     // The mint distribution was updated.
     MintDistributionCpv1 mint_distribution_cpv_1_update = 17;
+    // The gas rewards were updated (chain parameters version 2).
+    GasRewardsCpv2 gas_rewards_cpv_2_update = 18;
+    // The consensus timeouts were updated (chain parameters version 2).
+    TimeoutParameters timeout_parameters_update = 22;
+    // The minimum time between blocks was updated (chain parameters version 2).
+    Duration min_block_time_update = 23;
+    // The block energy limit was updated (chain parameters version 2).
+    Energy block_energy_limit_update = 24;
   }
 }
 
@@ -1751,6 +1790,9 @@ enum UpdateType {
     UPDATE_LEVEL2_KEYS = 13;
     UPDATE_COOLDOWN_PARAMETERS = 14;
     UPDATE_TIME_PARAMETERS = 15;
+    UPDATE_TIMEOUT_PARAMETERS = 16;
+    UPDATE_MIN_BLOCK_TIME = 17;
+    UPDATE_BLOCK_ENERGY_LIMIT = 18;
 }
 
 // The type of transaction.
@@ -2363,7 +2405,7 @@ message PendingUpdate {
     // Updates to the transaction fee distribution.
     TransactionFeeDistribution transaction_fee_distribution = 13;
     // Updates to the GAS rewards.
-    GasRewards gas_rewards = 14;
+    GasRewardsCpv0 gas_rewards_cpv_0 = 14;
     // Updates baker stake threshold. Is only relevant prior to protocol version 4.
     BakerStakeThreshold pool_parameters_cpv_0 = 15;
     // Updates pool parameters. Introduced in protocol version 4.
@@ -2376,6 +2418,14 @@ message PendingUpdate {
     CooldownParametersCpv1 cooldown_parameters = 19;
     // Updates to time parameters for chain parameters version 1 introduced in protocol version 4.
     TimeParametersCpv1 time_parameters = 20;
+    // Updates to the GAS rewards effective from protocol version 6 (chain parameters version 2).
+    GasRewardsCpv2 gas_rewards_cpv_2 = 21;
+    // Updates to the consensus timeouts for chain parameters version 2.
+    TimeoutParameters timeout_parameters = 22;
+    // Updates to the the minimum time between blocks for chain parameters version 2.
+    Duration min_block_time = 23;
+    // Updates to the block energy limit for chain parameters version 2.
+    Energy block_energy_limit = 24;
   }
 }
 
@@ -2830,7 +2880,7 @@ message ChainParametersV0 {
   // Current transaction fee distribution.
   TransactionFeeDistribution transaction_fee_distribution = 7;
   // Current gas reward parameters.
-  GasRewards gas_rewards = 8;
+  GasRewardsCpv0 gas_rewards = 8;
   // The foundation account.
   AccountAddress foundation_account = 9;
   // Minimum threshold for becoming a baker.
@@ -2843,7 +2893,7 @@ message ChainParametersV0 {
   AuthorizationsV0 level2_keys = 13;
 }
 
-// Updatable chain parameters that apply to protocol versions 1-3.
+// Updatable chain parameters that apply to protocol versions 4-5.
 message ChainParametersV1 {
   // Election difficulty for consensus lottery.
   ElectionDifficulty election_difficulty = 1;
@@ -2862,7 +2912,7 @@ message ChainParametersV1 {
   // Current transaction fee distribution.
   TransactionFeeDistribution transaction_fee_distribution = 8;
   // Current gas reward parameters.
-  GasRewards gas_rewards = 9;
+  GasRewardsCpv0 gas_rewards = 9;
   // The foundation account.
   AccountAddress foundation_account = 10;
   // Parameters governing baking pools and their commissions.
@@ -2874,6 +2924,39 @@ message ChainParametersV1 {
   // Keys allowed to do parameter updates.
   AuthorizationsV1 level2_keys = 14;
 }
+
+// Updatable chain parameters that apply to protocol versions 6.
+message ChainParametersV2 {
+  // Consensus parameters.
+  ConsensusParametersV1 consensus_parameters = 1;
+  // Euro per energy exchange rate.
+  ExchangeRate euro_per_energy = 2;
+  // Micro CCD per euro exchange rate.
+  ExchangeRate micro_ccd_per_euro = 3;
+  // Extra number of epochs before reduction in stake, or baker
+  // deregistration is completed.
+  CooldownParametersCpv1 cooldown_parameters = 4;
+  TimeParametersCpv1 time_parameters = 5;
+  // The limit for the number of account creations in a block.
+  CredentialsPerBlockLimit account_creation_limit = 6;
+  // Current mint distribution
+  MintDistributionCpv1 mint_distribution = 7;
+  // Current transaction fee distribution.
+  TransactionFeeDistribution transaction_fee_distribution = 8;
+  // Current gas reward parameters.
+  GasRewardsCpv2 gas_rewards = 9;
+  // The foundation account.
+  AccountAddress foundation_account = 10;
+  // Parameters governing baking pools and their commissions.
+  PoolParametersCpv1 pool_parameters = 11;
+  // Keys allowed to do root updates.
+  HigherLevelKeys root_keys = 12;
+  // Keys allowed to do level1 updates;
+  HigherLevelKeys level1_keys = 13;
+  // Keys allowed to do parameter updates.
+  AuthorizationsV1 level2_keys = 14;
+}
+
 
 // Chain parameters.
 message ChainParameters {

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1673,7 +1673,7 @@ message UpdatePayload {
     // The transaction fee distribtuion was updated.
     TransactionFeeDistribution transaction_fee_distribution_update = 7;
     // The gas rewards were updated.
-    GasRewardsCpv0 gas_rewards_cpv_0_update = 8;
+    GasRewards gas_rewards_update = 8;
     // The minimum amount of CCD needed to be come a baker was updated.
     BakerStakeThreshold baker_stake_threshold_update = 9;
     // The root keys were updated.
@@ -2904,6 +2904,9 @@ message ChainParametersV1 {
   // Extra number of epochs before reduction in stake, or baker
   // deregistration is completed.
   CooldownParametersCpv1 cooldown_parameters = 4;
+  // Current time parameters.
+  // The time parameters indicates the mint rate and the
+  // reward period length, i.e. the time between paydays.
   TimeParametersCpv1 time_parameters = 5;
   // The limit for the number of account creations in a block.
   CredentialsPerBlockLimit account_creation_limit = 6;
@@ -2936,6 +2939,9 @@ message ChainParametersV2 {
   // Extra number of epochs before reduction in stake, or baker
   // deregistration is completed.
   CooldownParametersCpv1 cooldown_parameters = 4;
+  // Current time parameters.
+  // The time parameters indicates the mint rate and the
+  // reward period length, i.e. the time between paydays.
   TimeParametersCpv1 time_parameters = 5;
   // The limit for the number of account creations in a block.
   CredentialsPerBlockLimit account_creation_limit = 6;

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1600,7 +1600,7 @@ message TransactionFeeDistribution {
 }
 
 // Distribution of gas rewards for chain parameters version 0 and 1.
-message GasRewardsCpv0 {
+message GasRewards {
   // The fraction paid to the baker.
   AmountFraction baker = 1;
   // Fraction paid for including a finalization proof in a block.
@@ -1695,11 +1695,11 @@ message UpdatePayload {
     // The gas rewards were updated (chain parameters version 2).
     GasRewardsCpv2 gas_rewards_cpv_2_update = 18;
     // The consensus timeouts were updated (chain parameters version 2).
-    TimeoutParameters timeout_parameters_update = 22;
+    TimeoutParameters timeout_parameters_update = 19;
     // The minimum time between blocks was updated (chain parameters version 2).
-    Duration min_block_time_update = 23;
+    Duration min_block_time_update = 20;
     // The block energy limit was updated (chain parameters version 2).
-    Energy block_energy_limit_update = 24;
+    Energy block_energy_limit_update = 21;
   }
 }
 
@@ -2405,7 +2405,7 @@ message PendingUpdate {
     // Updates to the transaction fee distribution.
     TransactionFeeDistribution transaction_fee_distribution = 13;
     // Updates to the GAS rewards.
-    GasRewardsCpv0 gas_rewards_cpv_0 = 14;
+    GasRewards gas_rewards = 14;
     // Updates baker stake threshold. Is only relevant prior to protocol version 4.
     BakerStakeThreshold pool_parameters_cpv_0 = 15;
     // Updates pool parameters. Introduced in protocol version 4.


### PR DESCRIPTION
## Purpose

Support the new chain parameters in the GRPC API V2

## Changes

New type definitions for types related to the new consensus. (P6)

- `ChainParametersV2`
    - `ConsensusParametersV1`
        - `TimeoutParamters`
            - timeout base
            - timeout increase
            - timeout decrease
        - `MinBlockTime`
        - `BlockEnergyLimit`
- `GasRewardsCpv2` (Does not support `finalization_proof` reward)


Changes to existing types: 

- The access structure for `parameter_election_difficulty` has been renamed to `parameter_consensus` as it will be the same set of keys that can change this properties of the chain.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

