### PR TITLE
Query by block height directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# Unreleased changes
+# Changelog
+
+## Unreleased changes
 
 - Expand `BlockHashInput` to support querying by block height.
 - Add `protocol_version` to the return of BlockInfo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Unreleased changes
+
+- Expand `BlockHashInput` to support querying by block height.
+- Add `protocol_version` to the return of BlockInfo.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -514,6 +514,7 @@ message BlockHashInput {
     BlockHash given = 3;
     // Query for a block at height, if a unique block can be identified at that height.
     AbsoluteBlockHeight absolute_height = 4;
+    // Query for a block at height relative to a genesis index.
     RelativeHeight relative_height = 5;
   }
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -495,6 +495,16 @@ message AccountInfo {
 
 // Input to queries which take a block as a parameter.
 message BlockHashInput {
+  // Request using a relative block height.
+  message RelativeHeight {
+    // Genesis index to start from.
+    GenesisIndex genesis_index = 1;
+    // Height starting from the genesis block at the genesis index.
+    BlockHeight height = 2;
+     // Whether to return results only from the specified genesis index (`true`),
+    // or allow results from more recent genesis indices as well (`false`).
+    bool restrict = 3;
+  }
   oneof block_hash_input {
     // Query for the best block.
     Empty best = 1;
@@ -502,6 +512,9 @@ message BlockHashInput {
     Empty last_final = 2;
     // Query for the block specified by the hash. This hash should always be 32 bytes.
     BlockHash given = 3;
+    // Query for a block at height, if a unique block can be identified at that height.
+    AbsoluteBlockHeight absolute_height = 4;
+    RelativeHeight relative_height = 5;
   }
 }
 
@@ -1986,6 +1999,8 @@ message BlockInfo {
   uint32 transactions_size = 15;
   // The hash of the block state after this block.
   StateHash state_hash = 16;
+  // Protocol version to which the block belongs.
+  ProtocolVersion protocol_version = 17;
 }
 
 // Request for GetPoolInfo.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -512,7 +512,7 @@ message BlockHashInput {
     Empty last_final = 2;
     // Query for the block specified by the hash. This hash should always be 32 bytes.
     BlockHash given = 3;
-    // Query for a block at height, if a unique block can be identified at that height.
+    // Query for a block at absolute height, if a unique block can be identified at that height.
     AbsoluteBlockHeight absolute_height = 4;
     // Query for a block at height relative to a genesis index.
     RelativeHeight relative_height = 5;


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-node/issues/837
Should be merged with https://github.com/Concordium/concordium-base/pull/374 and https://github.com/Concordium/concordium-node/pull/838

## Changes

- Add changelog for API v2.
- Provide the protocol version of the block in `GetBlockInfo`.
- Expand `BlockHashInput` to also take relative and absolute block height.

