### PR TITLE
Fix dummy grpc values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,9 @@
 
 - Expand `BlockHashInput` to support querying by block height.
 - Add `protocol_version` to the return of BlockInfo.
+- Make `slot_duration` optional in `ConsensusInfo`.
+- Add optional fields `current_timeout_duration`, `current_round`, `current_epoch`,
+  and `trigger_block_time` to `ConsensusInfo`.
+- Make `slot_number` optional in `BlockInfo`.
+- Add optional fields `round` and `epoch` to `BlockInfo`.
+- Make `election_difficulty` optional in `ElectionInfo`.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1888,7 +1888,7 @@ message ConsensusInfo {
   // Time of the (original) genesis block.
   Timestamp genesis_time = 3;
   // (Current) slot duration in milliseconds.
-  Duration slot_duration = 4;
+  optional Duration slot_duration = 4;
   // (Current) epoch duration in milliseconds.
   Duration epoch_duration = 5;
   // Hash of the last finalized block.
@@ -1945,6 +1945,10 @@ message ConsensusInfo {
   BlockHash current_era_genesis_block = 29;
   // Time when the current era started.
   Timestamp current_era_genesis_time = 30;
+  optional Duration current_timeout_duration = 31;
+  optional uint64 current_round = 32;
+  optional uint64 current_epoch = 33;
+  optional Timestamp trigger_block_time = 34;
 }
 
 // Information about an arrived block that is part of the streaming response.
@@ -1989,7 +1993,7 @@ message BlockInfo {
   // The time the block was verified.
   Timestamp arrive_time = 8;
   // The slot number in which the block was baked.
-  Slot slot_number = 9;
+  optional Slot slot_number = 9;
   // The time of the slot in which the block was baked.
   Timestamp slot_time = 10;
   // The baker id of account baking this block. Not provided for a genesis block.
@@ -2006,6 +2010,10 @@ message BlockInfo {
   StateHash state_hash = 16;
   // Protocol version to which the block belongs.
   ProtocolVersion protocol_version = 17;
+  // Block round
+  optional uint64 round = 18;
+  // Block epoch
+  optional uint64 epoch = 19;
 }
 
 // Request for GetPoolInfo.
@@ -2282,7 +2290,7 @@ message ElectionInfo {
   }
 
   // Baking lottery election difficulty.
-  ElectionDifficulty election_difficulty = 1;
+  optional ElectionDifficulty election_difficulty = 1;
   // Current leadership election nonce for the lottery.
   LeadershipElectionNonce election_nonce = 2;
   // List of the currently eligible bakers.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1887,7 +1887,7 @@ message ConsensusInfo {
   BlockHash genesis_block = 2;
   // Time of the (original) genesis block.
   Timestamp genesis_time = 3;
-  // (Current) slot duration in milliseconds.
+  // (Current) slot duration in milliseconds. Present in protocol versions 1-5.
   optional Duration slot_duration = 4;
   // (Current) epoch duration in milliseconds.
   Duration epoch_duration = 5;
@@ -1945,13 +1945,14 @@ message ConsensusInfo {
   BlockHash current_era_genesis_block = 29;
   // Time when the current era started.
   Timestamp current_era_genesis_time = 30;
-  // The current duration to wait before a round times out.
+  // The current duration to wait before a round times out. Present from protocol version 6.
   optional Duration current_timeout_duration = 31;
-  // The current round.
+  // The current round. Present from protocol version 6.
   optional uint64 current_round = 32;
-  // The current epoch.
+  // The current epoch. Present from protocol version 6.
   optional uint64 current_epoch = 33;
-  // The trigger block time of the seedstate of the last finalized block.
+  // The first block in the epoch with timestamp at least this is considered to be the trigger block
+  // for the epoch transition. Present from protocol version 6.
   optional Timestamp trigger_block_time = 34;
 }
 
@@ -1996,7 +1997,7 @@ message BlockInfo {
   Timestamp receive_time = 7;
   // The time the block was verified.
   Timestamp arrive_time = 8;
-  // The slot number in which the block was baked.
+  // The slot number in which the block was baked. Present in protocol versions 1-5.
   optional Slot slot_number = 9;
   // The time of the slot in which the block was baked.
   Timestamp slot_time = 10;
@@ -2014,9 +2015,9 @@ message BlockInfo {
   StateHash state_hash = 16;
   // Protocol version to which the block belongs.
   ProtocolVersion protocol_version = 17;
-  // Block round
+  // Block round. Present from protocol version 6.
   optional uint64 round = 18;
-  // Block epoch
+  // Block epoch. Present from protocol version 6.
   optional uint64 epoch = 19;
 }
 
@@ -2293,7 +2294,7 @@ message ElectionInfo {
     double lottery_power = 3;
   }
 
-  // Baking lottery election difficulty.
+  // Baking lottery election difficulty. Present in protocol versions 1-5.
   optional ElectionDifficulty election_difficulty = 1;
   // Current leadership election nonce for the lottery.
   LeadershipElectionNonce election_nonce = 2;

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1887,7 +1887,7 @@ message ConsensusInfo {
   BlockHash genesis_block = 2;
   // Time of the (original) genesis block.
   Timestamp genesis_time = 3;
-  // (Current) slot duration in milliseconds. Present in protocol versions 1-5.
+  // (Current) slot duration in milliseconds. Present only in protocol versions 1-5.
   optional Duration slot_duration = 4;
   // (Current) epoch duration in milliseconds.
   Duration epoch_duration = 5;

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2294,7 +2294,7 @@ message ElectionInfo {
     double lottery_power = 3;
   }
 
-  // Baking lottery election difficulty. Present in protocol versions 1-5.
+  // Baking lottery election difficulty. Present only in protocol versions 1-5.
   optional ElectionDifficulty election_difficulty = 1;
   // Current leadership election nonce for the lottery.
   LeadershipElectionNonce election_nonce = 2;

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1945,9 +1945,13 @@ message ConsensusInfo {
   BlockHash current_era_genesis_block = 29;
   // Time when the current era started.
   Timestamp current_era_genesis_time = 30;
+  // The current duration to wait before a round times out.
   optional Duration current_timeout_duration = 31;
+  // The current round.
   optional uint64 current_round = 32;
+  // The current epoch.
   optional uint64 current_epoch = 33;
+  // The trigger block time of the seedstate of the last finalized block.
   optional Timestamp trigger_block_time = 34;
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1549,6 +1549,11 @@ message Epoch {
   uint64 value = 1;
 }
 
+// A round.
+message Round {
+  uint64 value = 1;
+}
+
 // Length of a reward period in epochs.
 // Must always be a strictly positive number.
 message RewardPeriodLength {
@@ -1948,9 +1953,9 @@ message ConsensusInfo {
   // The current duration to wait before a round times out. Present from protocol version 6.
   optional Duration current_timeout_duration = 31;
   // The current round. Present from protocol version 6.
-  optional uint64 current_round = 32;
+  optional Round current_round = 32;
   // The current epoch. Present from protocol version 6.
-  optional uint64 current_epoch = 33;
+  optional Epoch current_epoch = 33;
   // The first block in the epoch with timestamp at least this is considered to be the trigger block
   // for the epoch transition. Present from protocol version 6.
   optional Timestamp trigger_block_time = 34;
@@ -2016,9 +2021,9 @@ message BlockInfo {
   // Protocol version to which the block belongs.
   ProtocolVersion protocol_version = 17;
   // Block round. Present from protocol version 6.
-  optional uint64 round = 18;
+  optional Round round = 18;
   // Block epoch. Present from protocol version 6.
-  optional uint64 epoch = 19;
+  optional Epoch epoch = 19;
 }
 
 // Request for GetPoolInfo.


### PR DESCRIPTION
## Purpose
To make the appropriate changes to the proto file in order to solve https://github.com/Concordium/concordium-node/issues/870. 

## Changes

Changes to the `ConsensusInfo` message type:
* `slot_duration` is now optional
* optional fields `current_timeout_duration`, `current_round`, `current_epoch`, `trigger_block_time` are added

Changes to the `BlockInfo` message type:
* `slot_number` is now optional
* optional fields `round` and `epoch` are added

Changes to the `ElectionInfo` message type:
* `election_difficulty` is now optional


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

