### PR TITLE
Support for `GetBlockCertificates`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `GetBakersRewardPeriod` endpoint.
+- Add `GetBlockCertificates` endpoint.
 
 ## Node 6.0 API
 

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -248,4 +248,11 @@ service Queries {
 
   // Get the items of a block.
   rpc GetBlockItems(BlockHashInput) returns (stream BlockItem);
+
+  // For a non-genesis block, this returns the quorum certificate, a timeout
+  // certificate (if present) and epoch finalization entry (if present).
+  // If the node does not support ConcordiumBFT (protocol versions < 6), then
+  // the response will be a grpc error (invalid argument) as the 'BlockHashInput'
+  // does not point to a block produced via ConcordiumBFT.
+  rpc GetBlockCertificates(BlockHashInput) returns (BlockCertificates);
 }

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -256,8 +256,9 @@ service Queries {
 
   // For a non-genesis block, this returns the quorum certificate, a timeout
   // certificate (if present) and epoch finalization entry (if present).
-  // If the node does not support ConcordiumBFT (protocol versions < 6), then
-  // the response will be a grpc error (invalid argument) as the 'BlockHashInput'
-  // does not point to a block produced via ConcordiumBFT.
+  // Note that, if the block being pointed to is not a product of ConcordiumBFT,
+  // then the response will be a grpc error (invalid argument).
+  // If the endpoint is not enabled by the node, then an 'unimplemented' error
+  // will be returned.
   rpc GetBlockCertificates(BlockHashInput) returns (BlockCertificates);
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -3103,3 +3103,105 @@ message BlockItem {
     UpdateInstruction update_instruction = 4;
   }
 }
+
+// The signature of a 'QuorumCertificate'.
+message QuorumSignature {
+  // The bytes representing the raw aggregate signature.
+  bytes value = 1;
+}
+
+// A quorum certificate is the certificate that the
+// finalization comittee issues in order to certify a block.
+// A block must be certified before it will be part of the
+// authorative part of the chain.
+message QuorumCertificate {
+  // The hash of the block that the quorum certificate refers to.
+  BlockHash block_hash = 1;
+  // The round of the block.
+  Round round = 2;
+  // The epoch of the block.
+  Epoch epoch = 3;
+  // The aggregated signature by the finalization committee on the block.
+  QuorumSignature aggregate_signature = 4;
+  // A list of the finalizers that formed the quorum certificate
+  // i.e., the ones who have contributed to the 'aggregate_siganture'.
+  // The finalizers are identified by their baker id as this is stable
+  // across protocols and epochs.
+  repeated BakerId signatories = 5;
+}
+
+// The finalizer round is a map from a 'Round'
+// to the list of finalizers (identified by their 'BakerId') that signed
+// off the round.
+message FinalizerRound {
+  // The round that was signed off.
+  Round round = 1;
+  // The finalizers (identified by their 'BakerId' that
+  // signed off the in 'round'.
+  repeated BakerId finalizers = 2;
+}
+
+// The signature of a 'TimeoutCertificate'.
+message TimeoutSignature {
+  // The bytes representing the raw aggregate signature.
+  bytes value = 1;
+}
+
+// A timeout certificate is the certificate that the
+// finalization committee issues when a round times out,
+// thus making it possible for the protocol to proceed to the
+// next round.
+message TimeoutCertificate {
+  // The round that timed out.
+  Round round = 1;
+  // The minimum epoch of which signatures are included
+  // in the 'aggregate_signature'.
+  Epoch min_epoch = 2;
+  // The rounds of which finalizers have their best
+  // QCs in the 'min_epoch'.
+  FinalizerRound qc_rounds_first_epoch = 3;
+  // The rounds of which finalizers have their best
+  // QCs in the epoch 'min_epoch' + 1.
+  FinalizerRound qc_rounds_second_epoch = 4;
+  // The aggregated signature by the finalization committee that witnessed
+  // the 'round' timed out.
+  TimeoutSignature aggregate_signature = 5;
+}
+
+// A proof that establishes that the successor block of
+// a 'EpochFinalizationEntry' is the immediate successor of
+// the finalized block.
+message SuccessorProof {
+  // The proof represented as raw bytes.
+  bytes value = 1;
+}
+
+// The epoch finalization entry is the proof that
+// makes to protocol able to advance to a new epoch.
+// I.e. the 'EpochFinalizationEntry' is present only
+// if the block is the first block of a new 'Epoch'.
+message EpochFinalizationEntry {
+  // The quorum certificate for the finalized block.
+  QuorumCertificate finalized_qc = 1;
+  // The quorum certificate for the block that finalizes
+  // the block that 'finalized_qc' points to.
+  QuorumCertificate successor_qc = 2;
+  // A proof that the successor block is an immediate
+  // successor of the finalized block.
+  SuccessorProof successor_proof = 3;
+}
+
+
+// Certificates for a block for protocols supporting
+// ConcordiumBFT.
+message BlockCertificates {
+  // The quorum certificate. Is present only if the block is
+  // not a genesis block.
+  optional QuorumCertificate quorum_certificate = 1;
+  // The timeout certificate. Is present only if the round prior to the
+  // round of the block timed out.
+  optional TimeoutCertificate timeout_certificate = 2;
+  // The epoch finalization entry. Is present only if the block initiates
+  // a new epoch.
+  optional EpochFinalizationEntry epoch_finalization_entry = 3;
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -3159,10 +3159,10 @@ message TimeoutCertificate {
   Epoch min_epoch = 2;
   // The rounds of which finalizers have their best
   // QCs in the 'min_epoch'.
-  FinalizerRound qc_rounds_first_epoch = 3;
+  repeated FinalizerRound qc_rounds_first_epoch = 3;
   // The rounds of which finalizers have their best
   // QCs in the epoch 'min_epoch' + 1.
-  FinalizerRound qc_rounds_second_epoch = 4;
+  repeated FinalizerRound qc_rounds_second_epoch = 4;
   // The aggregated signature by the finalization committee that witnessed
   // the 'round' timed out.
   TimeoutSignature aggregate_signature = 5;

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -3125,6 +3125,7 @@ message BakerRewardPeriodInfo {
 // The signature of a 'QuorumCertificate'.
 message QuorumSignature {
   // The bytes representing the raw aggregate signature.
+  // The bytes have a fixed length of 48 bytes.
   bytes value = 1;
 }
 
@@ -3162,6 +3163,7 @@ message FinalizerRound {
 // The signature of a 'TimeoutCertificate'.
 message TimeoutSignature {
   // The bytes representing the raw aggregate signature.
+  // The bytes have a fixed length of 48 bytes.
   bytes value = 1;
 }
 
@@ -3195,9 +3197,9 @@ message SuccessorProof {
 }
 
 // The epoch finalization entry is the proof that
-// makes to protocol able to advance to a new epoch.
-// I.e. the 'EpochFinalizationEntry' is present only
-// if the block is the first block of a new 'Epoch'.
+// makes the protocol able to advance to a new epoch.
+// I.e. the 'EpochFinalizationEntry' is present if and only if
+// the block is the first block of a new 'Epoch'.
 message EpochFinalizationEntry {
   // The quorum certificate for the finalized block.
   QuorumCertificate finalized_qc = 1;
@@ -3213,7 +3215,7 @@ message EpochFinalizationEntry {
 // Certificates for a block for protocols supporting
 // ConcordiumBFT.
 message BlockCertificates {
-  // The quorum certificate. Is present only if the block is
+  // The quorum certificate. Is present if and only if the block is
   // not a genesis block.
   optional QuorumCertificate quorum_certificate = 1;
   // The timeout certificate. Is present only if the round prior to the

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -3193,6 +3193,7 @@ message TimeoutCertificate {
 // the finalized block.
 message SuccessorProof {
   // The proof represented as raw bytes.
+  // The bytes have a fixed length of 32 bytes.
   bytes value = 1;
 }
 


### PR DESCRIPTION
## Purpose

Introduced the endpoint and types required to support `GetBlockCertificates`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

