### PR TITLE
Add commission rates to `PoolCurrentPaydayInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `GetBakersRewardPeriod` endpoint.
+- Add a `CommissionRates` field for `PoolCurrentPaydayInfo`.
 
 ## Node 6.0 API
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2072,6 +2072,8 @@ message PoolCurrentPaydayInfo {
   Amount baker_equity_capital = 6;
   // The effective delegated capital to the pool for the current reward period.
   Amount delegated_capital = 7;
+  // The commission rates that apply for the current reward period.
+  CommissionRates commission_rates = 8;
 }
 
 // Type for the response of GetPoolInfo.


### PR DESCRIPTION
## Purpose

Add the commission rates for the current reward period to `PoolCurrentPaydayInfo`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
