### PR TITLE
Add `GetWinningBakersEpoch` and `GetFirstBlockEpoch`.

### DIFF
--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -248,4 +248,29 @@ service Queries {
 
   // Get the items of a block.
   rpc GetBlockItems(BlockHashInput) returns (stream BlockItem);
+
+  // Get the list of bakers that won the lottery in a particular historical epoch (i.e. the
+  // last finalized block is in a later epoch). This lists the winners for each round in the
+  // epoch, starting from the round after the last block in the previous epoch, running to
+  // the round before the first block in the next epoch. It also indicates if a block in each
+  // round was included in the finalized chain.
+  //
+  // The following error cases are possible:
+  //  * `NOT_FOUND` if the query specifies an unknown block.
+  //  * `UNAVAILABLE` if the query is for an epoch that is not finalized in the current genesis
+  ///    index, or is for a future genesis index.
+  //  * `INVALID_ARGUMENT` if the query is for an epoch that is not finalized for a past genesis
+  //    index.
+  //  * `INVALID_ARGUMENT` if the query is for a genesis index at consensus version 0.
+  rpc GetWinningBakersEpoch (EpochRequest) returns (stream WinningBaker);
+
+  // Get the block hash of the first finalized block in a specified epoch.
+  //
+  // The following error cases are possible:
+  //  * `NOT_FOUND` if the query specifies an unknown block.
+  //  * `UNAVAILABLE` if the query is for an epoch that is not finalized in the current genesis
+  //    index, or is for a future genesis index.
+  //  * `INVALID_ARGUMENT` if the query is for an epoch with no finalized blocks for a past genesis
+  //    index.
+  rpc GetFirstBlockEpoch (EpochRequest) returns (BlockHash);
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -523,6 +523,24 @@ message BlockHashInput {
   }
 }
 
+// Input to queries which take an epoch as a parameter.
+message EpochRequest {
+    // Request an epoch by number at a given genesis index.
+    message RelativeEpoch {
+        // The genesis index to query at. The query is restricted to this genesis index, and
+        // will not return results for other indices even if the epoch number is out of bounds.
+        GenesisIndex genesis_index = 1;
+        // The epoch number to query at.
+        Epoch epoch = 2;
+    }
+    oneof epoch_request_input {
+        // Query by genesis index and epoch number.
+        RelativeEpoch relative_epoch = 1;
+        // Query for the epoch of a specified block.
+        BlockHashInput block_hash = 2;
+    }
+}
+
 // Input to queries which take an account as a parameter.
 message AccountIdentifierInput {
   oneof account_identifier_input {
@@ -3102,4 +3120,14 @@ message BlockItem {
     // to make future update instructions.
     UpdateInstruction update_instruction = 4;
   }
+}
+
+// Details of which baker won the lottery in a given round in consensus version 1.
+message WinningBaker {
+    // The round number.
+    Round round = 1;
+    // The baker that won the round.
+    BakerId winner = 2;
+    // True if the baker produced a block in this round on the finalized chain, and False otherwise.
+    bool present = 3;
 }


### PR DESCRIPTION
## Purpose

Add endpoints for getting the winning bakers for a historic epoch and for getting the first block of an epoch.

## Changes

- Add `EpochRequest` and `WinningBaker` types.
- Add `GetWinningBakersEpoch` and `GetFirstBlockEpoch` endpoints.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
