### PR TITLE
Add canonical grpc health check service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## Unreleased changes
+
+- Add a new health service that conforms to the API expected
+  by Google https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
+
+
+## Node 6.1.0
 
 - Add `GetBakersRewardPeriod` endpoint.
 - Add `GetBlockCertificates` endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,8 @@
 
 - Add a new health service that conforms to the API expected
   by Google https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
-
-
-## Node 6.1.0
-
 - Add `DryRun` endpoint.
-- Remove `UpdateInstructionSignature`
+- Remove `UpdateInstructionSignature`. It was not used in any endpoints.
 
 ## Node 6.1 API
 

--- a/grpc/health/v1/health.proto
+++ b/grpc/health/v1/health.proto
@@ -1,0 +1,73 @@
+// Copyright 2015 The gRPC Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The canonical version of this proto can be found at
+// https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto
+
+syntax = "proto3";
+
+package grpc.health.v1;
+
+option csharp_namespace = "Grpc.Health.V1";
+option go_package = "google.golang.org/grpc/health/grpc_health_v1";
+option java_multiple_files = true;
+option java_outer_classname = "HealthProto";
+option java_package = "io.grpc.health.v1";
+
+message HealthCheckRequest {
+  string service = 1;
+}
+
+message HealthCheckResponse {
+  enum ServingStatus {
+    UNKNOWN = 0;
+    SERVING = 1;
+    NOT_SERVING = 2;
+    SERVICE_UNKNOWN = 3;  // Used only by the Watch method.
+  }
+  ServingStatus status = 1;
+}
+
+// Health is gRPC's mechanism for checking whether a server is able to handle
+// RPCs. Its semantics are documented in
+// https://github.com/grpc/grpc/blob/master/doc/health-checking.md.
+service Health {
+  // Check gets the health of the specified service. If the requested service
+  // is unknown, the call will fail with status NOT_FOUND. If the caller does
+  // not specify a service name, the server should respond with its overall
+  // health status.
+  //
+  // Clients should set a deadline when calling Check, and can declare the
+  // server unhealthy if they do not receive a timely response.
+  //
+  // Check implementations should be idempotent and side effect free.
+  rpc Check(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Performs a watch for the serving status of the requested service.
+  // The server will immediately send back a message indicating the current
+  // serving status.  It will then subsequently send a new message whenever
+  // the service's serving status changes.
+  //
+  // If the requested service is unknown when the call is received, the
+  // server will send a message setting the serving status to
+  // SERVICE_UNKNOWN but will *not* terminate the call.  If at some
+  // future point, the serving status of the service becomes known, the
+  // server will send a new message with the service's serving status.
+  //
+  // If the call terminates with status UNIMPLEMENTED, then clients
+  // should assume this method is not supported and should not retry the
+  // call.  If the call terminates with any other status (including OK),
+  // clients should retry the call with appropriate exponential backoff.
+  rpc Watch(HealthCheckRequest) returns (stream HealthCheckResponse);
+}

--- a/v2/concordium/health.proto
+++ b/v2/concordium/health.proto
@@ -4,7 +4,7 @@ package concordium.health;
 
 // This specifies the package we want to use for our generated Java classes. 
 // Has no effect on code generated on other languages.
-option java_package = "com.concordium.grpc.v2";
+option java_package = "concordium.health";
 
 // This specifies that separate .java files will be generated for each of the Java classes/enums/etc. generated for the top-level messages, services, and enumerations, 
 // and the wrapper Java class generated for this .proto file won't contain any nested classes/enums/etc. 
@@ -13,7 +13,7 @@ option java_multiple_files = true;
 
 // This specifies the package we want to use for our generated C# classes. 
 // Has no effect on code generated on other languages.
-option csharp_namespace = "Concordium.Grpc.V2";
+option csharp_namespace = "Concordium.Health";
 
 // Parameters to the node health query. The default message gives a good
 // default.

--- a/v2/concordium/health.proto
+++ b/v2/concordium/health.proto
@@ -4,7 +4,7 @@ package concordium.health;
 
 // This specifies the package we want to use for our generated Java classes. 
 // Has no effect on code generated on other languages.
-option java_package = "concordium.health";
+option java_package = "com.concordium.health";
 
 // This specifies that separate .java files will be generated for each of the Java classes/enums/etc. generated for the top-level messages, services, and enumerations, 
 // and the wrapper Java class generated for this .proto file won't contain any nested classes/enums/etc. 


### PR DESCRIPTION
## Purpose

Add a new health check endpoint that fits to Google's requirement https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
