### PR TITLE
Remove `UpdateInstructionSignature`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Remove `UpdateInstructionSignature`
 - Add `GetBakersRewardPeriod` endpoint.
 - Add `GetBlockCertificates` endpoint.
 - Add `GetBakerEarliestWinTime` endpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - Remove `UpdateInstructionSignature`
+
+## Node 6.1 API
+
 - Add `GetBakersRewardPeriod` endpoint.
 - Add `GetBlockCertificates` endpoint.
 - Add `GetBakerEarliestWinTime` endpoint.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2806,7 +2806,7 @@ message Signature {
   bytes value = 1;
 }
 
-// A map from `UpdateKeysIndex` to `Signature`.
+// A signature on an update instruction.
 // The type `UpdateKeysIndex` is not used directly, as messages cannot be keys in maps.
 message SignatureMap {
   map<uint32, Signature> signatures = 1;

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2806,8 +2806,8 @@ message Signature {
   bytes value = 1;
 }
 
-// Wrapper for a map from indexes to signatures.
-// Needed because protobuf doesn't allow nested maps directly.
+// A map from `UpdateKeysIndex` to `Signature`.
+// The type `UpdateKeysIndex` is not used directly, as messages cannot be keys in maps.
 message SignatureMap {
   map<uint32, Signature> signatures = 1;
 }
@@ -2912,12 +2912,6 @@ message AccountTransaction {
   AccountTransactionSignature signature = 1;
   AccountTransactionHeader header = 2;
   AccountTransactionPayload payload = 3;
-}
-
-message UpdateInstructionSignature {
-  // A map from `UpdateKeysIndex` to `Signature`.
-  // The type `UpdateKeysIndex`is not used directly, as messages cannot be keys in maps.
-  map<uint32, Signature> signatures = 1;
 }
 
 message UpdateInstructionHeader {


### PR DESCRIPTION
## Purpose

It seems that the `UpdateInstructionSignature` and `AccountTransactionSignature` was meant to replace the `SignatureMap`. However it also seems that the `UpdateInstructionHeader` was never updated to include the `UpdateInstructionSignature` as intended.

Since the `SignatureMap` is only used in the `UpdateInstructionHeader` I propose to remove `UpdateInstructionHeader` and move the comments to `SignatureMap`. This should of course be a non-breaking change.


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
