### PR TITLE
Add protocol version 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `DryRun` endpoint.
 - Remove `UpdateInstructionSignature`. It was not used in any endpoints.
 - Remove V1 API.
+- Extend enum `ProtocolVersion` enum with a protocol version 7 variant `PROTOCOL_VERSION_7`.
 
 ## Node 6.1 API
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1892,6 +1892,7 @@ enum ProtocolVersion {
   PROTOCOL_VERSION_4 = 3;
   PROTOCOL_VERSION_5 = 4;
   PROTOCOL_VERSION_6 = 5;
+  PROTOCOL_VERSION_7 = 6;
 }
 
 // The number of chain restarts via a protocol update. An effected


### PR DESCRIPTION
## Purpose

Prepare the API for protocol version 7 as part of https://github.com/Concordium/concordium-node/issues/1066.

See also https://github.com/Concordium/concordium-base/pull/474 and https://github.com/Concordium/concordium-node/pull/1075.

