### PR TITLE
Endpoint for querying light blocks.

### DIFF
--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -336,4 +336,9 @@ service Queries {
   //    a bug.
   //  * `UNIMPLEMENTED` if the endpoint is disabled on the node.
   rpc DryRun (stream DryRunRequest) returns (stream DryRunResponse);
+
+  // Get a sequence of finalization proofs and Merkle finalization committee proofs that will
+  // allow a light client to update its current last finalized block from a trusted start block
+  // to a specified target block.
+  rpc GetLightBlocks (LightBlocksRequest) returns (stream LightBlocksItem);
 }

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -3540,3 +3540,53 @@ message DryRunSuccessResponse {
     }
 }
 
+// A request from a light client to catch up from a trusted block to a subsequent finalized
+// block.
+message LightBlocksRequest {
+    // The highest finalized block currently trusted by the light client.
+    BlockHashInput from = 1;
+    // The target finalized block to catch the light client up to.
+    // The request will fail if this is not descended from the 'from' block.
+    BlockHashInput to = 2;
+    // If true, indicates that the light client is not aware of the current epoch finalization
+    // committee for it's highest finalized block.
+    bool current_committee_unknown = 3;
+    // If true, indicates that the light client is not aware of the next epoch finalization
+    // committee for it's highest finalized block.
+    bool next_committee_unknown = 4;
+    // If true, the response should include a proof of the next epoch finalization committee for
+    // the 'to' block.
+    bool next_committee_required = 5;
+}
+
+// Representation of a generic Merkle proof.
+// A Merkle proof can be canonically converted to a root hash by converting each of its
+// branches to bytes, concatenating them, and then taking the SHA256 hash of the result.
+message MerkleProof {
+    // The branches of the Merkle proof.
+    repeated MerkleBranch branches = 1;
+}
+
+// Branches of a Merkle proof.
+// A Merkle branch is either raw data bytes or a sub-Merkle proof.
+message MerkleBranch {
+    oneof branch {
+        // Raw data bytes. For this case, 'raw_data' is the representation of the branch
+        // as bytes.
+        bytes raw_data = 1;
+        // A sub-proof. For this case, the root hash of 'sub_proof' is the representation
+        // of the branch as bytes.
+        MerkleProof sub_proof = 2;
+    }
+}
+
+// An item produced in response to a `LightBlocksRequest`.
+message LightBlocksItem {
+    oneof item {
+        // A finalization entry proving that a block is finalized, and checkable knowing
+        // the finalization committee for the epoch of the block.
+        EpochFinalizationEntry finalization_entry = 1;
+        // A Merkle proof of what the next or current epoch finalization committee is for a block.
+        MerkleProof committee_proof = 2;
+    }
+}


### PR DESCRIPTION
## Purpose

Add a GRPC endpoint for querying light client blocks. This returns a stream of proofs that can be used to catch up a light client from one block to another.

## Changes

- Add GetLightBlocks and associated types.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
