### PR TITLE
NOD598: Add new protocol version to proto types

### DIFF
--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1939,6 +1939,7 @@ enum ProtocolVersion {
   PROTOCOL_VERSION_5 = 4;
   PROTOCOL_VERSION_6 = 5;
   PROTOCOL_VERSION_7 = 6;
+  PROTOCOL_VERSION_8 = 7;
 }
 
 // The number of chain restarts via a protocol update. An effected


### PR DESCRIPTION
This adds the new protocol version 8 to the protobuf types.

## Purpose

Protocol version 8 will incorporate the suspension of inactive validators proposal.

## Changes

A new protocol version is added to the protobuf definitions.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
