### PR TITLE
protocol 8: New `is_suspended` flag for `AccountInfo`

### DIFF
--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -541,8 +541,11 @@ message AccountInfo {
   // the total amount that is actively staked or in cooldown (inactive stake).
   // This was introduced in node version 7.0.
   Amount available_balance = 12;
-  // A flag indicating whether the account is currently suspended or not. This
-  // was introduced in protocol version 8.
+  // A flag indicating whether the account is currently suspended or not. The
+  // flag has a meaning from protocol version 8 onwards. In protocol version 8
+  // it signals whether an account has been suspended and is not participating
+  // in the consensus algorithm. For protocol version < 8 the flag will always
+  // be set to true.
   bool is_suspended = 13;
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -541,6 +541,9 @@ message AccountInfo {
   // the total amount that is actively staked or in cooldown (inactive stake).
   // This was introduced in node version 7.0.
   Amount available_balance = 12;
+  // A flag indicating whether the account is currently suspended or not. This
+  // was introduced in protocol version 8.
+  bool is_suspended = 13;
 }
 
 // Input to queries which take a block as a parameter.


### PR DESCRIPTION
We add the `is_suspended` flag to the grpc representation of `AccountInfo`. This is a new flag indicating whether an account is currently suspended or not and is introduced in protocol 8.
