### PR TITLE
Add missing events for baker/delegator configure transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
     `delegated_capital`, `delegated_capital_cap` and `pool_info` optional. This
     is since in protocol 7 a validator can be unregistered, but still part of the
     current epoch validators.
-
+  - `BakerEvent` now has an additional case `delegation_removed`, as configuring a baker can
+    result in a delegator being removed (from protocol 7).
+  - `DelegationEvent` now has an additional case `baker_removed`, as configuring a delegator
+    can result in a baker being removed (from protocol 7).
 
 ## Node 6.2 API
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1196,6 +1196,11 @@ message BakerEvent {
     // The finalization reward commission
     AmountFraction finalization_reward_commission = 2;
   }
+  // Removed an existing delegator.
+  message DelegationRemoved {
+    // Delegator's id.
+    DelegatorId delegator_id = 1;
+  }
   oneof event {
     // A baker was added.
     BakerAdded baker_added = 1;
@@ -1219,6 +1224,8 @@ message BakerEvent {
     BakerSetBakingRewardCommission baker_set_baking_reward_commission = 10;
     // The baker's finalization reward commission was updated.
     BakerSetFinalizationRewardCommission baker_set_finalization_reward_commission = 11;
+    // An existing delegator was removed.
+    DelegationRemoved delegation_removed = 12;
   }
 }
 
@@ -1252,6 +1259,10 @@ message DelegationEvent {
     // New delegation target
     DelegationTarget delegation_target = 2;
   }
+  message BakerRemoved {
+    // Baker's id
+    BakerId baker_id = 1;
+  }
   oneof event {
     // The delegator's stake increased.
     DelegationStakeIncreased delegation_stake_increased = 1;
@@ -1265,6 +1276,8 @@ message DelegationEvent {
     DelegatorId delegation_added = 5;
     // A delegator was removed.
     DelegatorId delegation_removed = 6;
+    // An existing baker was removed.
+    BakerRemoved baker_removed = 7;
   }
 }
 


### PR DESCRIPTION
## Purpose

The changes to cooldown behaviour now allow an account to transition directly from delegator to baker and vice-versa. In these cases, an additional event is generated in the configure baker/delegator transaction to indicate that the delegator/baker has been removed.

## Changes

- Add `delegation_removed` and `baker_removed` events to `BakerEvent` and `DelegationEvent` respectively.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
