### PR TITLE
Remove trailing whitespace and extra `/` for comments

### DIFF
--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -8,16 +8,16 @@ package concordium.v2;
 // Has no effect on code generated on other languages.
 option go_package = "./pb";
 
-// This specifies the package we want to use for our generated Java classes. 
+// This specifies the package we want to use for our generated Java classes.
 // Has no effect on code generated on other languages.
 option java_package = "com.concordium.grpc.v2";
 
-// This specifies the package we want to use for our generated C# classes. 
+// This specifies the package we want to use for our generated C# classes.
 // Has no effect on code generated on other languages.
 option csharp_namespace = "Concordium.Grpc.V2";
 
-// This specifies that separate .java files will be generated for each of the Java classes/enums/etc. generated for the top-level messages, services, and enumerations, 
-// and the wrapper Java class generated for this .proto file won't contain any nested classes/enums/etc. 
+// This specifies that separate .java files will be generated for each of the Java classes/enums/etc. generated for the top-level messages, services, and enumerations,
+// and the wrapper Java class generated for this .proto file won't contain any nested classes/enums/etc.
 // If not generating Java code, this option has no effect.
 option java_multiple_files = true;
 
@@ -228,8 +228,8 @@ service Queries {
   // Returns a GRPC error if the network dump failed to be stopped.
   rpc DumpStop(Empty) returns (Empty);
 
-  /// Get a list of the peers that the node is connected to
-  /// and assoicated network related information for each peer.
+  // Get a list of the peers that the node is connected to
+  // and assoicated network related information for each peer.
   rpc GetPeersInfo(Empty) returns (PeersInfo);
 
   // Get information about the node.
@@ -291,7 +291,7 @@ service Queries {
   // The following error cases are possible:
   //  * `NOT_FOUND` if the query specifies an unknown block.
   //  * `UNAVAILABLE` if the query is for an epoch that is not finalized in the current genesis
-  ///    index, or is for a future genesis index.
+  //     index, or is for a future genesis index.
   //  * `INVALID_ARGUMENT` if the query is for an epoch that is not finalized for a past genesis
   //    index.
   //  * `INVALID_ARGUMENT` if the query is for a genesis index at consensus version 0.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -6,16 +6,16 @@ package concordium.v2;
 // Has no effect on code generated on other languages.
 option go_package = "./pb";
 
-// This specifies the package we want to use for our generated Java classes. 
+// This specifies the package we want to use for our generated Java classes.
 // Has no effect on code generated on other languages.
 option java_package = "com.concordium.grpc.v2";
 
-// This specifies that separate .java files will be generated for each of the Java classes/enums/etc. generated for the top-level messages, services, and enumerations, 
-// and the wrapper Java class generated for this .proto file won't contain any nested classes/enums/etc. 
+// This specifies that separate .java files will be generated for each of the Java classes/enums/etc. generated for the top-level messages, services, and enumerations,
+// and the wrapper Java class generated for this .proto file won't contain any nested classes/enums/etc.
 // If not generating Java code, this option has no effect.
 option java_multiple_files = true;
 
-// This specifies the package we want to use for our generated C# classes. 
+// This specifies the package we want to use for our generated C# classes.
 // Has no effect on code generated on other languages.
 option csharp_namespace = "Concordium.Grpc.V2";
 
@@ -3463,11 +3463,11 @@ message DryRunErrorResponse {
     }
 
     // The specified account was not found.
-    message AccountNotFound {   
+    message AccountNotFound {
     }
 
     // The specified instance was not found.
-    message InstanceNotFound {   
+    message InstanceNotFound {
     }
 
     // The amount that was requested to be minted would overflow the total supply.


### PR DESCRIPTION
## Purpose

Minor cleanup of doc comments, needed to fix some warnings for the generated code in C# SDK.
