### PR TITLE
p8: move suspended flag

### DIFF
--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -270,6 +270,12 @@ message AccountStakingInfo {
     // Present if the account is currently a baker, i.e., it is in the baking
     // committee of the current epoch.
     optional BakerPoolInfo pool_info = 5;
+    // A flag indicating whether the account is currently suspended or not. The
+    // flag has a meaning from protocol version 8 onwards. In protocol version 8
+    // it signals whether an account has been suspended and is not participating
+    // in the consensus algorithm. For protocol version < 8 the flag will always
+    // be set to false.
+    bool is_suspended = 6;
   }
 
   message Delegator {
@@ -541,12 +547,6 @@ message AccountInfo {
   // the total amount that is actively staked or in cooldown (inactive stake).
   // This was introduced in node version 7.0.
   Amount available_balance = 12;
-  // A flag indicating whether the account is currently suspended or not. The
-  // flag has a meaning from protocol version 8 onwards. In protocol version 8
-  // it signals whether an account has been suspended and is not participating
-  // in the consensus algorithm. For protocol version < 8 the flag will always
-  // be set to false.
-  bool is_suspended = 13;
 }
 
 // Input to queries which take a block as a parameter.


### PR DESCRIPTION
This moves the suspended flag from `AccountInfo` to `AccountStakingInfo.Baker`.

## Purpose

Reflect that the the suspended flag is associated to validators, not the account.

## Changes

see above.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
