### PR TITLE
Queries for getting which accounts have scheduled releases or cooldowns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
     events to `BakerEvent`.
 - Add `GetConsensusDetailedStatus` endpoint for querying detailed consensus
   status information.
+- Add `GetScheduledReleaseAccounts` endpoint for querying the list of accounts that
+  have scheduled releases.
+- Add `GetCooldownAccounts`, `GetPreCooldownAccounts` and `GetPrePreCooldownAccounts`
+  endpoints for querying the lists of account that have pending cooldowns in protocol
+  version 7 onwards.
 
 ## Node 7.0 API
 

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -174,6 +174,25 @@ service Queries {
   // Get next available sequence numbers for updating chain parameters after a given block.
   rpc GetNextUpdateSequenceNumbers (BlockHashInput) returns (NextUpdateSequenceNumbers);
 
+  // Get all accounts that have scheduled releases, with the timestamp of the first pending
+  // scheduled release for that account.  (Note, this only identifies accounts by index, and
+  // only indicates the first pending release for each account.)
+  rpc GetScheduledReleaseAccounts (BlockHashInput) returns (stream AccountPending);
+
+  // Get all accounts that have stake in cooldown, with the timestamp of the first pending
+  // cooldown expiry for each account. (Note, this only identifies accounts by index,
+  // and only indicates the first pending cooldown for each account.)
+  // Prior to protocol version 7, the resulting stream will always be empty.
+  rpc GetCooldownAccounts (BlockHashInput) returns (stream AccountPending);
+
+  // Get all accounts (by account index) that have stake in pre-cooldown.
+  // Prior to protocol version 7, the resulting stream will always be empty.
+  rpc GetPreCooldownAccounts (BlockHashInput) returns (stream AccountIndex);
+
+  // Get all accounts (by account index) that have stake in pre-pre-cooldown.
+  // Prior to protocol version 7, the resulting stream will always be empty.
+  rpc GetPrePreCooldownAccounts (BlockHashInput) returns (stream AccountIndex);
+
   // Get the projected earliest time at which a particular baker will be required to bake a block.
   // If the current consensus version is 0, this returns the status 'Unavailable', as the endpoint
   // is only supported by consensus version 1.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -3929,3 +3929,10 @@ message ConsensusDetailedStatus {
     // If a protocol update has occurred, this is the hash of the terminal block.
     optional BlockHash terminal_block = 16;
 }
+
+// Indicates that an account is pending -- either a scheduled release or a cooldown -- and
+// when the first release or cooldown will elapse.
+message AccountPending {
+    AccountIndex account_index = 1;
+    Timestamp first_timestamp = 2;
+}


### PR DESCRIPTION
## Purpose

Issue: https://github.com/Concordium/concordium-node/issues/1263
Related: https://github.com/Concordium/concordium-base/pull/575 https://github.com/Concordium/concordium-node/pull/1260

Add gRPC endpoints for getting the lists of accounts with scheduled releases or cooldowns.

## Changes

- GetScheduledReleaseAccounts endpoint
- GetCooldownAccounts endpoint
- GetPreCooldownAccounts endpoint
- GetPrePreCooldownAccounts endpoint

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
