### PR TITLE
Added account address to ValidatorSuspended/PrimedForSuspension

### DIFF
--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2550,6 +2550,8 @@ message BlockSpecialEvent {
   message ValidatorSuspended {
     // The id of the suspended validator.
     BakerId bakerId = 1;
+    // The account of the suspended validator.
+    AccountAddress account = 2;
   }
 
   // The id of a validator that is primed for suspension at the next snapshot
@@ -2557,6 +2559,8 @@ message BlockSpecialEvent {
   message ValidatorPrimedForSuspension {
     // The id of the primed validator.
     BakerId bakerId = 1;
+    // The account of the primed validator.
+    AccountAddress account = 2;
   }
 
   oneof event {


### PR DESCRIPTION
## Purpose

We add the account address of the suspended/primed validator to the special events. This is needed for tooling.

## Changes

See above.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
