### PR TITLE
Suspend info in `PoolInfoResponse` and `PoolCurrentPaydayInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     events to `BakerEvent`.
   - Added `validator_suspended` and `validator_primed_for_suspension` cases
     for `BlockSpecialEvent`.
+  - Extended `PoolCurrentPaydayInfo` and `PoolInfoResponse`.
 - Add `GetConsensusDetailedStatus` endpoint for querying detailed consensus
   status information.
 - Add `GetScheduledReleaseAccounts` endpoint for querying the list of accounts that

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2187,9 +2187,11 @@ message PoolCurrentPaydayInfo {
   // The commission rates that apply for the current reward period.
   CommissionRates commission_rates = 8;
   // A flag indicating whether the pool owner is primed for suspension.
-  bool is_primed_for_suspension = 9;
+  // Absent if the protocol version does not support validator suspension.
+  optional bool is_primed_for_suspension = 9;
   // The number of missed rounds in the current reward period.
-  uint64 missed_rounds = 10;
+  // Absent if the protocol version does not support validator suspension.
+  optional uint64 missed_rounds = 10;
 }
 
 // Type for the response of GetPoolInfo.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2225,7 +2225,8 @@ message PoolInfoResponse {
   // Total capital staked across all pools, including passive delegation.
   Amount all_pool_total_capital = 9;
   // A flag indicating whether the pool owner is suspended.
-  bool is_suspended = 10;
+  // Absent if the protocol version does not support validator suspension.
+  optional bool is_suspended = 10;
 }
 
 // Type for the response of GetPassiveDelegationInfo.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2186,6 +2186,10 @@ message PoolCurrentPaydayInfo {
   Amount delegated_capital = 7;
   // The commission rates that apply for the current reward period.
   CommissionRates commission_rates = 8;
+  // A flag indicating whether the pool owner is primed for suspension.
+  bool is_primed_for_suspension = 9;
+  // The number of missed rounds in the current reward period.
+  uint64 missed_rounds = 10;
 }
 
 // Type for the response of GetPoolInfo.
@@ -2218,6 +2222,8 @@ message PoolInfoResponse {
   optional PoolCurrentPaydayInfo current_payday_info = 8;
   // Total capital staked across all pools, including passive delegation.
   Amount all_pool_total_capital = 9;
+  // A flag indicating whether the pool owner is suspended.
+  bool is_suspended = 10;
 }
 
 // Type for the response of GetPassiveDelegationInfo.


### PR DESCRIPTION
## Purpose

Add suspension info to `PoolInfo` /  `PoolCurrentPaydayInfo`.

## Changes

See above.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
