### PR TITLE
Clarify when `is_suspended` may be absent.

### DIFF
--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2225,7 +2225,7 @@ message PoolInfoResponse {
   // Total capital staked across all pools, including passive delegation.
   Amount all_pool_total_capital = 9;
   // A flag indicating whether the pool owner is suspended.
-  // Absent if the protocol version does not support validator suspension.
+  // Absent if the protocol version does not support validator suspension or the pool is removed.
   optional bool is_suspended = 10;
 }
 


### PR DESCRIPTION
## Purpose

Relates to: https://github.com/Concordium/concordium-node/issues/1309

Clarify when `is_suspended` may be absent.
