### PR TITLE
plt: Implement token data structures and account integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Extend `ProtocolVersion` enum with a protocol version 9 variant `PROTOCOL_VERSION_9`.
 - Support for protocol level tokens.
   - Added account / block level token state.
-  - Token identifiers
-  - Token events (mint, burn, add/remove allow-list, add/remove deny-list)
+  - Token identifiers.
+  - Token governance / holder events.
   - Endpoint to query token block level state.
 
 ## Node 8.0 API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## Unreleased changes
 
 - Extend `ProtocolVersion` enum with a protocol version 9 variant `PROTOCOL_VERSION_9`.
+- Support for protocol level tokens.
+  - Added account / block level token state.
+  - Token identifiers
+  - Token events (mint, burn, add/remove allow-list, add/remove deny-list)
+  - Endpoint to query token block level state.
 
 ## Node 8.0 API
 

--- a/v2/concordium/kernel.proto
+++ b/v2/concordium/kernel.proto
@@ -1,0 +1,35 @@
+// This file currently exists to prevent circular dependencies when extracting
+// PLT functionality into its own package. The file name `kernel` is choosen
+// in anticipation of more core definitions operating at the module/core
+// intersection to follow.
+
+syntax = "proto3";
+
+package concordium.v2;
+
+// This specifies the package we want to use for our generated Go code.
+// Has no effect on code generated on other languages.
+option go_package = "./pb";
+
+// This specifies the package we want to use for our generated Java classes.
+// Has no effect on code generated on other languages.
+option java_package = "com.concordium.grpc.v2";
+
+// This specifies that separate .java files will be generated for each of the Java classes/enums/etc. generated for the top-level messages, services, and enumerations,
+// and the wrapper Java class generated for this .proto file won't contain any nested classes/enums/etc.
+// If not generating Java code, this option has no effect.
+option java_multiple_files = true;
+
+// This specifies the package we want to use for our generated C# classes.
+// Has no effect on code generated on other languages.
+option csharp_namespace = "Concordium.Grpc.V2";
+
+// An address of an account. Always 32 bytes.
+message AccountAddress {
+  bytes value = 1;
+}
+
+// A memo which can be included as part of a transfer. Max size is 256 bytes.
+message Memo {
+  bytes value = 1;
+}

--- a/v2/concordium/protocol-level-tokens.proto
+++ b/v2/concordium/protocol-level-tokens.proto
@@ -21,6 +21,12 @@ option csharp_namespace = "Concordium.Grpc.V2.Plt";
 
 import "kernel.proto";
 
+// A Cbor encoded bytestring
+message CBor {
+  // A CBOR encoded byte string.
+  bytes value = 1;
+}
+
 // The unique symbol and identifier of a protocol level token.
 message TokenId {
   // Unique identifier for the token, guaranteed to be distinct across the
@@ -44,30 +50,17 @@ message TokenAmount {
 
 // Token state at the block level
 message TokenState {
-  // The token name. This should be unique, but uniqueness is enforced only by
-  // the chain governance, not by the consensus protocol.
-  string token_name = 1;
   // The reference of the module implementing this token.
-  TokenModuleRef token_module_ref = 2;
+  TokenModuleRef token_module_ref = 1;
   // Account address of the issuer. The issuer is the holder of the nominated
   // account which can perform token-governance operations.
-  concordium.v2.AccountAddress issuer = 3;
+  concordium.v2.AccountAddress issuer = 2;
   // Number of decimals in the decimal number representation of amounts.
-  uint32 nr_of_decimals = 4;
-  // A URL pointing to additional meta information about the token.
-  optional string token_meta_url = 5;
-
-  // Whether the token supports an allow list.
-  bool supports_allow_list = 6;
-  // Whether the token supports a deny list.
-  bool supports_deny_list = 7;
-  // Whether the token supports minting.
-  bool supports_miniting = 8;
-  // Whether the token supports burning.
-  bool supports_burning = 9;
-
+  uint32 nr_of_decimals = 3;
   // The total available token supply.
-  TokenAmount total_supply = 10;
+  TokenAmount total_supply = 4;
+  // Token module specific state, such as token name, feature flags, meta data. 
+  CBor module_state = 5;
 }
 
 // Token state at the account level
@@ -86,59 +79,20 @@ message TokenAccountState {
 
 // Token events originating from governance transactions.
 message TokenGovernanceEvent {
-  message Mint {
-    concordium.v2.AccountAddress account_address = 1;
-    TokenAmount amount = 2;
-  }
-
-  message Burn {
-    concordium.v2.AccountAddress account_address = 1;
-    TokenAmount amount = 2;
-  }
-
-  message AddAllowList {
-    concordium.v2.AccountAddress account_address = 1;
-  }
-
-  message RemoveAllowList {
-    concordium.v2.AccountAddress account_address = 1;
-  }
-
-  message AddDenyList {
-    concordium.v2.AccountAddress account_address = 1;
-  }
-
-  message RemoveDenyList {
-    concordium.v2.AccountAddress account_address = 1;
-  }
-
-  // The token id of the event.
+  // The unique token symbol.
   TokenId token_symbol = 1;
-  // The event.
-  oneof event {
-    Mint mint = 2;
-    Burn burn = 3;
-    AddAllowList add_allow_list = 4;
-    RemoveAllowList remove_allow_list = 5;
-    AddDenyList add_deny_list = 6;
-    RemoveDenyList remove_deny_list = 7;
-  }
+  // The type of the event.
+  string type  = 2;
+  // The CBOR encoded event details.
+  CBor details = 3;
 }
 
 //Token events originating from account transactions.
 message TokenHolderEvent {
-  // A token transfer between two accounts.
-  message Transfer {
-    TokenAmount amount = 2;
-    concordium.v2.AccountAddress from_address = 3;
-    concordium.v2.AccountAddress to_address = 4;
-    optional concordium.v2.Memo memo = 5;
-  }
-
-  // The token id of the event.
-  TokenId symbol = 1;
-  // The event.
-  oneof event {
-    Transfer transfer = 2;
-  }
+  // The unique token symbol.
+  TokenId token_symbol = 1;
+  // The type of the event.
+  string type  = 2;
+  // The CBOR encoded event details.
+  CBor details = 3;
 }

--- a/v2/concordium/protocol-level-tokens.proto
+++ b/v2/concordium/protocol-level-tokens.proto
@@ -1,0 +1,144 @@
+syntax = "proto3";
+
+package concordium.v2.plt;
+
+// This specifies the package we want to use for our generated Go code.
+// Has no effect on code generated on other languages.
+option go_package = "./pb";
+
+// This specifies the package we want to use for our generated Java classes.
+// Has no effect on code generated on other languages.
+option java_package = "com.concordium.grpc.v2.plt";
+
+// This specifies that separate .java files will be generated for each of the Java classes/enums/etc. generated for the top-level messages, services, and enumerations,
+// and the wrapper Java class generated for this .proto file won't contain any nested classes/enums/etc.
+// If not generating Java code, this option has no effect.
+option java_multiple_files = true;
+
+// This specifies the package we want to use for our generated C# classes.
+// Has no effect on code generated on other languages.
+option csharp_namespace = "Concordium.Grpc.V2.Plt";
+
+import "kernel.proto";
+
+// The unique symbol and identifier of a protocol level token.
+message TokenId {
+  // Unique identifier for the token, guaranteed to be distinct across the
+  // entire concordium blockchain.
+  string symbol = 1;
+}
+
+// A token module reference. This is always 32 bytes long.
+message TokenModuleRef {
+  bytes value = 1;
+}
+
+// PLT amount representation. The actual amount is computed as `digits *
+// 10^(-nr_of_decimals)`.
+message TokenAmount {
+  // The digits of the amount.
+  uint64 digits = 1;
+  // Number of decimals in the representation
+  uint32 nr_of_decimals = 2;
+}
+
+// Token state at the block level
+message TokenState {
+  // The token name. This should be unique, but uniqueness is enforced only by
+  // the chain governance, not by the consensus protocol.
+  string token_name = 1;
+  // The reference of the module implementing this token.
+  TokenModuleRef token_module_ref = 2;
+  // Account address of the issuer. The issuer is the holder of the nominated
+  // account which can perform token-governance operations.
+  concordium.v2.AccountAddress issuer = 3;
+  // Number of decimals in the decimal number representation of amounts.
+  uint32 nr_of_decimals = 4;
+  // A URL pointing to additional meta information about the token.
+  optional string token_meta_url = 5;
+
+  // Whether the token supports an allow list.
+  bool supports_allow_list = 6;
+  // Whether the token supports a deny list.
+  bool supports_deny_list = 7;
+  // Whether the token supports minting.
+  bool supports_miniting = 8;
+  // Whether the token supports burning.
+  bool supports_burning = 9;
+
+  // The total available token supply.
+  TokenAmount total_supply = 10;
+}
+
+// Token state at the account level
+message TokenAccountState {
+  // The available balance.
+  TokenAmount balance = 1;
+  // Whether the account is a member of the allow list of the token.
+  // If present, tokens can be transferred only, if both sender and receiver are
+  // members of the allow list of the token.
+  optional bool member_allow_list = 2;
+  // Whether the account is a member of the deny list of the token.
+  // If present, tokens can be transferred only, if neither sender or receiver
+  // are members of the deny list.
+  optional bool member_deny_list = 3;
+}
+
+// Token events originating from governance transactions.
+message TokenGovernanceEvent {
+  message Mint {
+    concordium.v2.AccountAddress account_address = 1;
+    TokenAmount amount = 2;
+  }
+
+  message Burn {
+    concordium.v2.AccountAddress account_address = 1;
+    TokenAmount amount = 2;
+  }
+
+  message AddAllowList {
+    concordium.v2.AccountAddress account_address = 1;
+  }
+
+  message RemoveAllowList {
+    concordium.v2.AccountAddress account_address = 1;
+  }
+
+  message AddDenyList {
+    concordium.v2.AccountAddress account_address = 1;
+  }
+
+  message RemoveDenyList {
+    concordium.v2.AccountAddress account_address = 1;
+  }
+
+  // The token id of the event.
+  TokenId token_symbol = 1;
+  // The event.
+  oneof event {
+    Mint mint = 2;
+    Burn burn = 3;
+    AddAllowList add_allow_list = 4;
+    RemoveAllowList remove_allow_list = 5;
+    AddDenyList add_deny_list = 6;
+    RemoveDenyList remove_deny_list = 7;
+  }
+}
+
+//Token events originating from account transactions.
+message TokenHolderEvent {
+  // A token transfer between two accounts.
+  message Transfer {
+    TokenAmount amount = 2;
+    concordium.v2.AccountAddress from_address = 3;
+    concordium.v2.AccountAddress to_address = 4;
+    optional concordium.v2.Memo memo = 5;
+  }
+
+  // The token id of the event.
+  TokenId symbol = 1;
+  // The event.
+  oneof event {
+    Transfer transfer = 2;
+  }
+}

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -36,6 +36,9 @@ service Queries {
   // Retrieve the information about the given account in the given block.
   rpc GetAccountInfo (AccountInfoRequest) returns (AccountInfo);
 
+  // Retrieve the information about the given token in the given block.
+  rpc GetTokenInfo (TokenInfoRequest) returns (TokenInfo);
+
   // Retrieve the list of accounts that exist at the end of the given block.
   rpc GetAccountList (BlockHashInput) returns (stream AccountAddress);
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -19,6 +19,9 @@ option java_multiple_files = true;
 // Has no effect on code generated on other languages.
 option csharp_namespace = "Concordium.Grpc.V2";
 
+import "kernel.proto";
+import "protocol-level-tokens.proto";
+
 // A message that contains no information.
 message Empty {
 }
@@ -337,11 +340,6 @@ message EncryptionKey {
   bytes value = 1;
 }
 
-// An address of an account. Always 32 bytes.
-message AccountAddress {
-  bytes value = 1;
-}
-
 // An address of either a contract or an account.
 message Address {
   oneof type {
@@ -503,8 +501,24 @@ message Cooldown {
   CooldownStatus status = 3;
 }
 
+// The token state at the block level.
+message TokenInfo {
+  // The unique token id.
+  plt.TokenId token_id = 1;
+  // The associated block level state.
+  plt.TokenState token_state = 2;
+}
+
 // Information about the account at a particular point in time.
 message AccountInfo {
+  // Protocol level token (PLT).
+  message Token {
+    // The unique token id
+    plt.TokenId token_id = 1;
+    // The associated token account level state
+    plt.TokenAccountState token_account_state = 2;
+  }
+
   // Next sequence number to be used for transactions signed from this account.
   SequenceNumber sequence_number = 1;
   // Current (unencrypted) balance of the account.
@@ -541,12 +555,15 @@ message AccountInfo {
   // This was introduced in protocol version 7, and so is not present in
   // earlier protocol versions.
   repeated Cooldown cooldowns = 11;
-  // The available (unencrypted) balance of the account (i.e. that can be transferred
-  // or used to pay for transactions). This is the balance minus the locked amount.
-  // The locked amount is the maximum of the amount in the release schedule and
-  // the total amount that is actively staked or in cooldown (inactive stake).
-  // This was introduced in node version 7.0.
+  // The available (unencrypted) balance of CCD's of the account (i.e. that
+  // can be transferred or used to pay for transactions). This is the balance
+  // minus the locked amount. The locked amount is the maximum of the amount
+  // in the release schedule and the total amount that is actively staked or in
+  // cooldown (inactive stake). This was introduced in node version 7.0.
   Amount available_balance = 12;
+
+  // The protocol level tokens (PLT) held by the account.
+  repeated Token tokens = 13;
 }
 
 // Input to queries which take a block as a parameter.
@@ -611,6 +628,14 @@ message AccountInfoRequest {
   BlockHashInput block_hash = 1;
   // Specification of the account.
   AccountIdentifierInput account_identifier = 2;
+}
+
+// Request for token information.
+message TokenInfoRequest {
+  // Block in which to query the token information.
+  BlockHashInput block_hash = 1;
+  // Specification of the token identifier.
+  plt.TokenId token_id = 2;
 }
 
 // Information about a finalized block that is part of the streaming response.
@@ -1086,11 +1111,6 @@ message BakerKeysEvent {
     BakerAggregationVerifyKey aggregation_key = 5;
 }
 
-// A memo which can be included as part of a transfer. Max size is 256 bytes.
-message Memo {
-  bytes value = 1;
-}
-
 message BakerStakeUpdatedData {
   // Affected baker.
   BakerId baker_id = 1;
@@ -1425,6 +1445,10 @@ message AccountTransactionEffects {
     BakerConfigured baker_configured = 18;
     // A delegator was configured. The details of what happened are contained in a list of DelegatorEvents.
     DelegationConfigured delegation_configured = 19;
+    // A token holder event.
+    plt.TokenHolderEvent token_holder_event = 20;
+    // Events originating from token governance.
+    plt.TokenGovernanceEvent token_governance_event = 21;
   }
 }
 


### PR DESCRIPTION
Define protobuf message types for:
- Token account/block level state
- Token identifiers
- Token events for token operations (transfer, mint, burn)

Extend `AccountInfo` structure to incorporate token state (balance, allow/deny list), enabling token support within existing account framework.

Mermaid diagrams of the current design proposal:
`types.proto`: https://gist.github.com/drsk0/388bef8640220d54a479d3f39eb52599
`protocol-level-tokens.proto`: https://gist.github.com/drsk0/80f8fd34509b3f9cc046e9e028f5b1ed
`kernel.proto`: https://gist.github.com/drsk0/77e3e4787f3383083485721d5a3e2f63
`services.proto`: https://gist.github.com/drsk0/c352e07a55093adfaa51de8b137644db



## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
