### PR TITLE
plt: use root relative import paths

### DIFF
--- a/v2/concordium/protocol-level-tokens.proto
+++ b/v2/concordium/protocol-level-tokens.proto
@@ -19,7 +19,7 @@ option java_multiple_files = true;
 // Has no effect on code generated on other languages.
 option csharp_namespace = "Concordium.Grpc.V2.Plt";
 
-import "kernel.proto";
+import "v2/concordium/kernel.proto";
 
 // A Cbor encoded bytestring
 message CBor {

--- a/v2/concordium/service.proto
+++ b/v2/concordium/service.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 import "v2/concordium/types.proto";
+import "v2/concordium/kernel.proto";
 
 package concordium.v2;
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -19,8 +19,8 @@ option java_multiple_files = true;
 // Has no effect on code generated on other languages.
 option csharp_namespace = "Concordium.Grpc.V2";
 
-import "kernel.proto";
-import "protocol-level-tokens.proto";
+import "v2/concordium/kernel.proto";
+import "v2/concordium/protocol-level-tokens.proto";
 
 // A message that contains no information.
 message Empty {


### PR DESCRIPTION
For the haskell build, it's important that the proto imports are relative to the root of the repository. Also service.proto was lacking an import.
