### PR TITLE
Add token governance transaction type and reject reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
   - Extend `reason` oneof in `RejectReason` with:
     - `non_existent_token_id`: the transaction referred to a protocol-level token that
        does not exist.
-    - `token_holder_transction_failed`: the token-holder transaction failed.
+    - `token_holder_transaction_failed`: the token-holder transaction failed.
+    - `token_governance_transaction_failed`: the token-governance transaction failed.
     - `unauthorized_token_governance`: Sender account is not authorized for governing the provided protocol level token.
 
 ## Node 8.0 API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 - Extend `ProtocolVersion` enum with a protocol version 9 variant `PROTOCOL_VERSION_9`.
 - Support for protocol level tokens.
-  - Added account / block level token state.
-  - Token identifiers.
-  - Token governance / holder events.
-  - Endpoint to query token block level state.
-  - Endpoint to query list of existing protocol level tokens.
+  - Extend `AccountInfo` with `tokens` field for account state per token.
+  - Extend enum `TransactionType` with values `TOKEN_HOLDER`/`TOKEN_GOVERNANCE` representing token holder/governance transactions.
+  - Extend enum `UpdateType` with value `UPDATE_CREATE_PLT` representing chain updates creating protocol level tokens.
+  - Extend `effect` oneof in `AccountTransactionEffects` with `token_holder_effect` and `token_governance_effect`.
+  - Extend `reason` oneof in `RejectReason` with `non_existent_token_id` and `unauthorized_token_governance`.
+  - Add rpc endpoint `GetTokenInfo` for accessing state of each token for some block.
+  - Add rpc endpoint `GetTokenList` to query list of existing protocol level tokens for some block.
 
 ## Node 8.0 API
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -991,6 +991,8 @@ message RejectReason {
     Empty pool_closed = 54;
     // The provided identifier does not match a token currently on chain.
     plt.TokenId non_existent_token_id = 55;
+    // Account sending the transaction is not authorized for governing the token.
+    plt.TokenId unauthorized_token_governance = 56;
   }
 }
 
@@ -2003,6 +2005,7 @@ enum TransactionType {
   CONFIGURE_DELEGATION = 20;
   // Introduced in protocol version 9.
   TOKEN_HOLDER = 21;
+  TOKEN_GOVERNANCE = 22;
 }
 
 // The different versions of the protocol.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -995,8 +995,11 @@ message RejectReason {
     // The token-holder transaction failed.
     // Introduced in protocol version 9.
     plt.TokenModuleRejectReason token_holder_transaction_failed = 56;
+    // The token-governance transaction failed.
+    // Introduced in protocol version 9.
+    plt.TokenModuleRejectReason token_governance_transaction_failed = 57;
     // Account sending the transaction is not authorized for governing the token.
-    plt.TokenId unauthorized_token_governance = 57;
+    plt.TokenId unauthorized_token_governance = 58;
   }
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -2005,6 +2005,7 @@ enum TransactionType {
   CONFIGURE_DELEGATION = 20;
   // Introduced in protocol version 9.
   TOKEN_HOLDER = 21;
+  // Introduced in protocol version 9.
   TOKEN_GOVERNANCE = 22;
 }
 


### PR DESCRIPTION
## Purpose

Support for token governance transactions (ref COR-688)

Related PR for base https://github.com/Concordium/concordium-base/pull/622
Related PR for node: https://github.com/Concordium/concordium-node/pull/1371

## Changes

- Extend with transaction type variant for `TokenGovernance` transactions.
- Introduce reject reason representing: Unauthorized for token governance.