### PR TITLE
PLT initialization

### DIFF
--- a/v2/concordium/protocol-level-tokens.proto
+++ b/v2/concordium/protocol-level-tokens.proto
@@ -108,3 +108,13 @@ message TokenHolderEffect {
   // Events emitted by the token.
   repeated TokenHolderEvent events = 1;
 }
+
+// Details provided by the token module in the event of rejecting a transaction.
+message TokenModuleRejectReason {
+    // The token symbol.
+    TokenId token_symbol = 1;
+    // The type of the reject reason.
+    string type = 2;
+    // (Optional) CBOR-encoded details.
+    optional CBor details = 3;
+}

--- a/v2/concordium/protocol-level-tokens.proto
+++ b/v2/concordium/protocol-level-tokens.proto
@@ -118,3 +118,19 @@ message TokenModuleRejectReason {
     // (Optional) CBOR-encoded details.
     optional CBor details = 3;
 }
+
+// Update payload for creating a new protocol-level token
+message CreatePLT {
+    // The token symbol.
+    TokenId token_symbol = 1;
+    // The hash that identifies the token module implementation.
+    TokenModuleRef token_module = 2;
+    // The address of the account that will govern the token.
+    AccountAddress governance_account = 3;
+    // The number of decimal places used in the representation of amounts of this token.
+    // This determines the smallest representable fraction of the token.
+    // This can be at most 255.
+    uint32 decimals = 4;
+    // The initialization parameters of the token, encoded in CBOR.
+    CBor initialization_parameters = 5;
+}

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1886,6 +1886,8 @@ message UpdatePayload {
     FinalizationCommitteeParameters finalization_committee_parameters_update = 22;
     // Validator score parameters (chain parameters version 3)
     ValidatorScoreParameters validator_score_parameters_update = 23;
+    // Create a new protocol-level token.
+    plt.CreatePLT create_plt_update = 24;
   }
 }
 
@@ -1924,14 +1926,19 @@ message TransactionTime {
   uint64 value = 1;
 }
 
-// Details of an update instruction. These are free, and we only ever get a
+// Details of an successful update instruction. These are free, and we only ever get a
 // response for them if the update is successfully enqueued, hence no failure
 // cases.
 message UpdateDetails {
   // The time at which the update will be effective.
   TransactionTime effective_time = 1;
-  // The paylaod for the update.
+  // The payload for the update.
   UpdatePayload payload = 2;
+}
+
+message FailedUpdateDetails {
+  // The reason for rejecting the update transaction.
+  RejectReason reject_reason = 1;
 }
 
 // Summary of the outcome of a block item in structured form.
@@ -1953,8 +1960,11 @@ message BlockItemSummary {
     AccountTransactionDetails account_transaction = 4;
     // Details about an account creation.
     AccountCreationDetails account_creation = 5;
-    // Details about a chain update.
+    // Details about a successful chain update.
     UpdateDetails update = 6;
+    // Details about a rejected chain update.
+    // This only applies to protocol-level token chain governance updates.
+    FailedUpdateDetails failed_update = 7;
   }
 }
 

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -989,6 +989,12 @@ message RejectReason {
     Empty pool_would_become_over_delegated = 53;
     // The pool is not open to delegators.
     Empty pool_closed = 54;
+    // Tried to create a protocol-level token where a token with the same `TokenId` exists.
+    plt.TokenId token_exists = 55;
+    // Tried to create a protocol-level token but the specified token module is invalid.
+    plt.TokenModuleRef token_module_invalid = 56;
+    // Tried to create a protocol-level token, but the token module's initializer failed.
+    plt.TokenModuleRejectReason token_module_initialize_failed = 57;
   }
 }
 


### PR DESCRIPTION
## Purpose

Support for PLT initialization.

## Changes

- Add `TokenModuleRejectReason` to represent reject reasons defined by the token module.
- Add `CreatePLT` payload as an `UpdatePayload`.
- New `RejectReason`s: `token_exists`, `token_module_invalid` and `token_module_initialize_failed`.
- Add a `failed_update` case to `BlockItemSummary` for supporting failing chain updates.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

