### PR TITLE
Rename `TokenAmount` fields

### DIFF
--- a/v2/concordium/protocol-level-tokens.proto
+++ b/v2/concordium/protocol-level-tokens.proto
@@ -39,13 +39,13 @@ message TokenId {
 // A token module reference. This is always 32 bytes long.
 message TokenModuleRef { bytes value = 1; }
 
-// PLT amount representation. The actual amount is computed as `digits *
-// 10^(-nr_of_decimals)`.
+// PLT amount representation. The actual amount is computed as
+// `value * 10^(-decimals)`.
 message TokenAmount {
   // The digits of the amount.
-  uint64 digits = 1;
+  uint64 value = 1;
   // Number of decimals in the representation
-  uint32 nr_of_decimals = 2;
+  uint32 decimals = 2;
 }
 
 // Token state at the block level
@@ -56,7 +56,7 @@ message TokenState {
   // account which can perform token-governance operations.
   concordium.v2.AccountAddress issuer = 2;
   // Number of decimals in the decimal number representation of amounts.
-  uint32 nr_of_decimals = 3;
+  uint32 decimals = 3;
   // The total available token supply.
   TokenAmount total_supply = 4;
   // Token module specific state, such as token name, feature flags, meta data.


### PR DESCRIPTION
## Purpose

Rename the fields of `TokenAmount` to match the proposed JSON names.

## Changes

- `TokenAmount`:
  - `digits` to `value`
  - `nr_of_decimals` to `decimals`
- `TokenState`:
  - `nr_of_decimals` to `decimals`

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

