### PR TITLE
Max lock duration execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Add the P11 `lock_duration_too_long` reject reason for PLT lock creation beyond `max_lock_duration`.
+
 - Add P11 `token_parameters` authorization, optional `max_lock_duration` chain parameter, `max_lock_duration_update` update payload, pending update effect, update type, and next update sequence number fields.
 - Extend `ProtocolVersion` enum with a protocol version 11 variant `PROTOCOL_VERSION_11`.
 - Extend `Service` with a new RPC `GetTokenAuthorizations` to enable querying token authorizations for a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 ## Unreleased changes
 
-- Add the P11 `lock_duration_too_long` reject reason for PLT lock creation beyond `max_lock_duration`.
-
 - Add P11 `token_parameters` authorization, optional `max_lock_duration` chain parameter, `max_lock_duration_update` update payload, pending update effect, update type, and next update sequence number fields.
+- Add the P11 `lock_duration_too_long` reject reason for PLT lock creation beyond `max_lock_duration`.
 - Extend `ProtocolVersion` enum with a protocol version 11 variant `PROTOCOL_VERSION_11`.
 - Extend `Service` with a new RPC `GetTokenAuthorizations` to enable querying token authorizations for a
   given token.

--- a/v2/concordium/types.proto
+++ b/v2/concordium/types.proto
@@ -1059,6 +1059,8 @@ message RejectReason {
     LockTokenNotPermitted lock_token_not_permitted = 63;
     // The recipient is not permitted to receive funds controlled by the lock.
     LockOperationNotAuthorized lock_recipient_not_permitted = 64;
+    // The requested expiry exceeds the maximum permitted lock duration.
+    plt.LockId lock_duration_too_long = 65;
   }
 }
 


### PR DESCRIPTION
Ref COR-2335

## Purpose

Add reject reason for transactions failing due to lock creation expiry bounds

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.